### PR TITLE
get /articles/{slug}/comments に JWT 認証の分岐を追加

### DIFF
--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/domain/CommentRepository.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/domain/CommentRepository.kt
@@ -7,11 +7,20 @@ import com.example.realworldkotlinspringbootjdbc.domain.user.UserId
 import com.example.realworldkotlinspringbootjdbc.util.MyError
 
 interface CommentRepository {
+    fun list(slug: Slug): Either<ListUnauthorizedError, List<Comment>> = TODO()
+    sealed interface ListUnauthorizedError : MyError {
+        data class NotFoundArticleBySlug(val slug: Slug) : ListUnauthorizedError, MyError.Basic
+        data class Unexpected(override val cause: Throwable, val slug: Slug) :
+            ListUnauthorizedError,
+            MyError.MyErrorWithThrowable
+    }
+
     fun list(slug: Slug, currentUserId: UserId): Either<ListError, List<Comment>> = TODO()
     sealed interface ListError : MyError {
         data class NotFoundArticleBySlug(val slug: Slug) : ListError, MyError.Basic
         data class Unexpected(override val cause: Throwable, val slug: Slug) : ListError, MyError.MyErrorWithThrowable
     }
+
     fun create(body: Body): Either<CreateError, Comment> = TODO()
     sealed interface CreateError : MyError {
         data class Unexpected(override val cause: Throwable, val body: Body) : CreateError, MyError.MyErrorWithThrowable

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/domain/CommentRepository.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/domain/CommentRepository.kt
@@ -3,10 +3,11 @@ package com.example.realworldkotlinspringbootjdbc.domain
 import arrow.core.Either
 import com.example.realworldkotlinspringbootjdbc.domain.article.Slug
 import com.example.realworldkotlinspringbootjdbc.domain.comment.Body
+import com.example.realworldkotlinspringbootjdbc.domain.user.UserId
 import com.example.realworldkotlinspringbootjdbc.util.MyError
 
 interface CommentRepository {
-    fun list(slug: Slug): Either<ListError, List<Comment>> = TODO()
+    fun list(slug: Slug, currentUserId: UserId): Either<ListError, List<Comment>> = TODO()
     sealed interface ListError : MyError {
         data class NotFoundArticleBySlug(val slug: Slug) : ListError, MyError.Basic
         data class Unexpected(override val cause: Throwable, val slug: Slug) : ListError, MyError.MyErrorWithThrowable

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
@@ -124,13 +124,13 @@ class CommentController(
                 /**
                  * コメント取得に失敗
                  */
-                is Left -> when (val useCaseError = result.value) {
+                is Left -> when (result.value) {
                     /**
                      * 原因: バリデーションエラー
                      */
                     is ListCommentUseCase.Error.InvalidSlug -> ResponseEntity(
-                        serializeMyErrorListForResponseBody(useCaseError.errors),
-                        HttpStatus.valueOf(422)
+                        serializeUnexpectedErrorForResponseBody("記事が見つかりませんでした"), // TODO: serializeUnexpectedErrorForResponseBodyをやめる
+                        HttpStatus.valueOf(404)
                     )
                     /**
                      * 原因: 記事が見つかりませんでした

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
@@ -39,7 +39,13 @@ class CommentController(
         @PathVariable("slug") slug: String?
     ): ResponseEntity<String> {
         return when (val authorizeResult = myAuth.authorize(rawAuthorizationHeader)) {
+            /**
+             * JWT 認証 失敗 or 未ログイン
+             */
             is Left -> TODO()
+            /**
+             * JWT 認証 成功
+             */
             is Right -> when (val result = listCommentUseCase.execute(slug, Some(authorizeResult.value))) {
                 /**
                  * コメント取得に成功

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
@@ -27,10 +27,10 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @Tag(name = "Comments")
 class CommentController(
+    val myAuth: MyAuth,
     val listCommentUseCase: ListCommentUseCase,
     val createCommentUseCase: CreateCommentUseCase,
-    val deleteCommentUseCase: DeleteCommentUseCase,
-    val myAuth: MyAuth
+    val deleteCommentUseCase: DeleteCommentUseCase
 ) {
     @GetMapping("/articles/{slug}/comments")
     fun list(@PathVariable("slug") slug: String?): ResponseEntity<String> {

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentController.kt
@@ -2,7 +2,6 @@ package com.example.realworldkotlinspringbootjdbc.presentation
 
 import arrow.core.Either.Left
 import arrow.core.Either.Right
-import arrow.core.None
 import arrow.core.Some
 import com.example.realworldkotlinspringbootjdbc.presentation.request.NullableComment
 import com.example.realworldkotlinspringbootjdbc.presentation.request.NullableCommentId
@@ -43,7 +42,7 @@ class CommentController(
             /**
              * JWT 認証 失敗 or 未ログイン
              */
-            is Left -> when (val result = listCommentUseCase.execute(slug, None)) {
+            is Left -> when (val result = listCommentUseCase.execute(slug)) {
                 /**
                  * コメント取得に失敗
                  */

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
@@ -18,7 +18,7 @@ import com.example.realworldkotlinspringbootjdbc.util.MyError
 import org.springframework.stereotype.Service
 
 interface ListCommentUseCase {
-    fun execute(slug: String?, currentUser: Option<RegisteredUser>): Either<Error, List<Comment>> = TODO()
+    fun execute(slug: String?, currentUser: Option<RegisteredUser> = None): Either<Error, List<Comment>> = TODO()
     sealed interface Error : MyError {
         data class InvalidSlug(override val errors: List<MyError.ValidationError>) : Error, MyError.ValidationErrors
         data class NotFound(override val cause: MyError) : Error, MyError.MyErrorWithMyError

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
@@ -9,7 +9,6 @@ import arrow.core.Some
 import arrow.core.Validated.Invalid
 import arrow.core.Validated.Valid
 import arrow.core.left
-import arrow.core.right
 import com.example.realworldkotlinspringbootjdbc.domain.Comment
 import com.example.realworldkotlinspringbootjdbc.domain.CommentRepository
 import com.example.realworldkotlinspringbootjdbc.domain.RegisteredUser
@@ -67,7 +66,7 @@ class ShowCommentUseCaseImpl(
                     /**
                      * コメントの取得 成功
                      */
-                    is Right -> listResult.value.right()
+                    is Right -> listResult
                 }
                 /**
                  * JWT 認証成功
@@ -92,7 +91,7 @@ class ShowCommentUseCaseImpl(
                     /**
                      * コメントの取得 成功
                      */
-                    is Right -> listResult.value.right()
+                    is Right -> listResult
                 }
             }
         }

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
@@ -3,18 +3,22 @@ package com.example.realworldkotlinspringbootjdbc.usecase
 import arrow.core.Either
 import arrow.core.Either.Left
 import arrow.core.Either.Right
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
 import arrow.core.Validated.Invalid
 import arrow.core.Validated.Valid
 import arrow.core.left
 import arrow.core.right
 import com.example.realworldkotlinspringbootjdbc.domain.Comment
 import com.example.realworldkotlinspringbootjdbc.domain.CommentRepository
+import com.example.realworldkotlinspringbootjdbc.domain.RegisteredUser
 import com.example.realworldkotlinspringbootjdbc.domain.article.Slug
 import com.example.realworldkotlinspringbootjdbc.util.MyError
 import org.springframework.stereotype.Service
 
 interface ListCommentUseCase {
-    fun execute(slug: String?): Either<Error, List<Comment>> = TODO()
+    fun execute(slug: String?, currentUser: Option<RegisteredUser>): Either<Error, List<Comment>> = TODO()
     sealed interface Error : MyError {
         data class InvalidSlug(override val errors: List<MyError.ValidationError>) : Error, MyError.ValidationErrors
         data class NotFound(override val cause: MyError) : Error, MyError.MyErrorWithMyError
@@ -26,27 +30,48 @@ interface ListCommentUseCase {
 class ShowCommentUseCaseImpl(
     val commentRepository: CommentRepository
 ) : ListCommentUseCase {
-    override fun execute(slug: String?): Either<ListCommentUseCase.Error, List<Comment>> {
+    override fun execute(
+        slug: String?,
+        currentUser: Option<RegisteredUser>
+    ): Either<ListCommentUseCase.Error, List<Comment>> {
         return when (val it = Slug.new(slug)) {
+            /**
+             * Slug が不正
+             */
             is Invalid -> ListCommentUseCase.Error.InvalidSlug(it.value).left()
-            is Valid -> when (val listResult = commentRepository.list(it.value)) {
+            /**
+             * Slug が適切
+             */
+            is Valid -> when (currentUser) {
                 /**
-                 * コメントの取得 成功
+                 * JWT 認証 失敗 or 未ログイン
                  */
-                is Right -> listResult.value.right()
+                is None -> TODO()
                 /**
-                 * コメントの取得失敗
+                 * JWT 認証成功
                  */
-                is Left -> when (val listError = listResult.value) {
+                is Some -> when (val listResult = commentRepository.list(it.value, currentUser.value.userId)) {
                     /**
-                     * 原因: Slug に該当する記事が見つからなかった
+                     * コメントの取得失敗
                      */
-                    is CommentRepository.ListError.NotFoundArticleBySlug -> ListCommentUseCase.Error.NotFound(listError)
-                        .left()
+                    is Left -> when (val listError = listResult.value) {
+                        /**
+                         * 原因: Slug に該当する記事が見つからなかった
+                         */
+                        is CommentRepository.ListError.NotFoundArticleBySlug -> ListCommentUseCase.Error.NotFound(
+                            listError
+                        )
+                            .left()
+                        /**
+                         * 原因: 不明
+                         */
+                        is CommentRepository.ListError.Unexpected -> ListCommentUseCase.Error.Unexpected(listError)
+                            .left()
+                    }
                     /**
-                     * 原因: 不明
+                     * コメントの取得 成功
                      */
-                    is CommentRepository.ListError.Unexpected -> ListCommentUseCase.Error.Unexpected(listError).left()
+                    is Right -> listResult.value.right()
                 }
             }
         }

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
@@ -46,7 +46,29 @@ class ShowCommentUseCaseImpl(
                 /**
                  * JWT 認証 失敗 or 未ログイン
                  */
-                is None -> TODO()
+                is None -> when (val listResult = commentRepository.list(it.value)) {
+                    /**
+                     * コメントの取得失敗
+                     */
+                    is Left -> when (val listError = listResult.value) {
+                        /**
+                         * 原因: Slug に該当する記事が見つからなかった
+                         */
+                        is CommentRepository.ListUnauthorizedError.NotFoundArticleBySlug -> ListCommentUseCase.Error.NotFound(
+                            listError
+                        ).left()
+                        /**
+                         * 原因: 不明
+                         */
+                        is CommentRepository.ListUnauthorizedError.Unexpected -> ListCommentUseCase.Error.Unexpected(
+                            listError
+                        ).left()
+                    }
+                    /**
+                     * コメントの取得 成功
+                     */
+                    is Right -> listResult.value.right()
+                }
                 /**
                  * JWT 認証成功
                  */

--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/usecase/ListCommentUseCase.kt
@@ -82,8 +82,7 @@ class ShowCommentUseCaseImpl(
                          */
                         is CommentRepository.ListError.NotFoundArticleBySlug -> ListCommentUseCase.Error.NotFound(
                             listError
-                        )
-                            .left()
+                        ).left()
                         /**
                          * 原因: 不明
                          */

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -332,13 +332,18 @@ class CommentControllerTest {
 
         @Test
         fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
-            val notImplementedError = object : MyError {}
+            /**
+             * FIXME
+             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mockE に修正
+             * 命名規則の方針が決まり次第修正
+             */
+            val mockE = object : MyError {}
             val listReturnUnexpectedError = object : ListCommentUseCase {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
                 ): Either<ListCommentUseCase.Error, List<Comment>> {
-                    return ListCommentUseCase.Error.Unexpected(notImplementedError).left()
+                    return ListCommentUseCase.Error.Unexpected(mockE).left()
                 }
             }
             val actual = commentController(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -266,28 +266,28 @@ class CommentControllerTest {
             assertThat(actual).isEqualTo(expected)
         }
 
-        // @Test
-        // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
-        //     val notImplementedError = object : MyError {}
-        //     val listReturnNotFoundError = object : ListCommentUseCase {
-        //         override fun execute(
-        //             slug: String?,
-        //             currentUser: Option<RegisteredUser>
-        //         ): Either<ListCommentUseCase.Error, List<Comment>> =
-        //             ListCommentUseCase.Error.NotFound(notImplementedError).left()
-        //     }
-        //     val actual = commentController(
-        //         unauthorizedMyAuth,
-        //         listReturnNotFoundError,
-        //         notImplementedCreateCommentUseCase,
-        //         notImplementedDeleteCommentUseCase
-        //     ).list(
-        //         requestHeader,
-        //         pathParam
-        //     )
-        //     val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
-        //     assertThat(actual).isEqualTo(expected)
-        // }
+        @Test
+        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
+            val notImplementedError = object : MyError {}
+            val listReturnNotFoundError = object : ListCommentUseCase {
+                override fun execute(
+                    slug: String?,
+                    currentUser: Option<RegisteredUser>
+                ): Either<ListCommentUseCase.Error, List<Comment>> =
+                    ListCommentUseCase.Error.NotFound(notImplementedError).left()
+            }
+            val actual = commentController(
+                unauthorizedMyAuth,
+                listReturnNotFoundError,
+                notImplementedCreateCommentUseCase,
+                notImplementedDeleteCommentUseCase
+            ).list(
+                requestHeader,
+                pathParam
+            )
+            val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
+            assertThat(actual).isEqualTo(expected)
+        }
 
         // @Test
         // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -40,10 +40,10 @@ class CommentControllerTest {
             Image.newWithoutValidation("dummy-image"),
         )
         private fun commentController(
+            myAuth: MyAuth,
             commentsUseCase: ListCommentUseCase,
             createCommentUseCase: CreateCommentUseCase,
-            deleteCommentUseCase: DeleteCommentUseCase,
-            myAuth: MyAuth
+            deleteCommentUseCase: DeleteCommentUseCase
         ): CommentController =
             CommentController(myAuth, commentsUseCase, createCommentUseCase, deleteCommentUseCase)
 
@@ -96,10 +96,10 @@ class CommentControllerTest {
             }
             val actual =
                 commentController(
+                    authorizedMyAuth,
                     listReturnComment,
                     notImplementedCreateCommentUseCase,
-                    notImplementedDeleteCommentUseCase,
-                    authorizedMyAuth
+                    notImplementedDeleteCommentUseCase
                 ).list(
                     requestHeader,
                     pathParam
@@ -122,10 +122,10 @@ class CommentControllerTest {
                     ListCommentUseCase.Error.NotFound(notImplementedError).left()
             }
             val actual = commentController(
+                authorizedMyAuth,
                 listReturnNotFoundError,
                 notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase,
-                authorizedMyAuth
+                notImplementedDeleteCommentUseCase
             ).list(
                 requestHeader,
                 pathParam
@@ -149,10 +149,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 listReturnValidationError,
                 notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase,
-                authorizedMyAuth
+                notImplementedDeleteCommentUseCase
             ).list(
                 requestHeader,
                 pathParam
@@ -176,10 +176,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 listReturnUnexpectedError,
                 notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase,
-                authorizedMyAuth
+                notImplementedDeleteCommentUseCase
             ).list(
                 requestHeader,
                 pathParam
@@ -210,10 +210,10 @@ class CommentControllerTest {
         private val notImplementedListCommentUseCase = object : ListCommentUseCase {}
         private val notImplementedDeleteCommentUseCase = object : DeleteCommentUseCase {}
         private fun commentController(
+            myAuth: MyAuth,
             listCommentUseCase: ListCommentUseCase,
             createCommentUseCase: CreateCommentUseCase,
-            deleteCommentUseCase: DeleteCommentUseCase,
-            myAuth: MyAuth
+            deleteCommentUseCase: DeleteCommentUseCase
         ): CommentController =
             CommentController(myAuth, listCommentUseCase, createCommentUseCase, deleteCommentUseCase)
 
@@ -245,10 +245,10 @@ class CommentControllerTest {
             }
             val actual =
                 commentController(
+                    authorizedMyAuth,
                     notImplementedListCommentUseCase,
                     createCommentUseCase,
-                    notImplementedDeleteCommentUseCase,
-                    authorizedMyAuth
+                    notImplementedDeleteCommentUseCase
                 ).create(pathParam, pathParam, requestBody)
             val expected = ResponseEntity(
                 """{"Comment":{"id":1,"body":"hoge-body","createdAt":"2021-12-31T15:00:00.000Z","updatedAt":"2021-12-31T15:00:00.000Z","author":"hoge-username"}}""",
@@ -269,10 +269,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 createReturnValidationError,
-                notImplementedDeleteCommentUseCase,
-                authorizedMyAuth
+                notImplementedDeleteCommentUseCase
             ).create(requestHeader, pathParam, requestBody)
             val expected = ResponseEntity(
                 """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because Invalid Slug"}]}}""",
@@ -293,10 +293,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 createReturnValidationError,
-                notImplementedDeleteCommentUseCase,
-                authorizedMyAuth
+                notImplementedDeleteCommentUseCase
             ).create(requestHeader, pathParam, requestBody)
             val expected = ResponseEntity(
                 """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because invalid CommentBody"}]}}""",
@@ -314,10 +314,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 createReturnNotFoundError,
-                notImplementedDeleteCommentUseCase,
-                authorizedMyAuth
+                notImplementedDeleteCommentUseCase
             ).create(requestHeader, pathParam, requestBody)
             val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
             assertThat(actual).isEqualTo(expected)
@@ -332,10 +332,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 createReturnUnexpectedError,
                 notImplementedDeleteCommentUseCase,
-                authorizedMyAuth,
             ).create(requestHeader, pathParam, requestBody)
             val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
             assertThat(actual).isEqualTo(expected)
@@ -357,10 +357,10 @@ class CommentControllerTest {
         private val notImplementedListCommentUseCase = object : ListCommentUseCase {}
         private val notImplementedCreateCommentUseCase = object : CreateCommentUseCase {}
         private fun commentController(
+            myAuth: MyAuth,
             listCommentUseCase: ListCommentUseCase,
             createCommentUseCase: CreateCommentUseCase,
-            deleteCommentUseCase: DeleteCommentUseCase,
-            myAuth: MyAuth
+            deleteCommentUseCase: DeleteCommentUseCase
         ): CommentController =
             CommentController(myAuth, listCommentUseCase, createCommentUseCase, deleteCommentUseCase)
 
@@ -378,10 +378,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 notImplementedCreateCommentUseCase,
-                deleteCommentUseCase,
-                authorizedMyAuth
+                deleteCommentUseCase
             ).delete(requestHeader, pathParamSlug, pathParamCommentId)
             val expected = ResponseEntity("", HttpStatus.valueOf(200))
             assertThat(actual).isEqualTo(expected)
@@ -399,10 +399,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 notImplementedCreateCommentUseCase,
-                deleteReturnValidationError,
-                authorizedMyAuth
+                deleteReturnValidationError
             ).delete(requestHeader, pathParamSlug, pathParamCommentId)
             val expected = ResponseEntity(
                 """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because Invalid Slug"}]}}""",
@@ -423,10 +423,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 notImplementedCreateCommentUseCase,
-                deleteReturnValidationError,
-                authorizedMyAuth
+                deleteReturnValidationError
             ).delete(requestHeader, pathParamSlug, pathParamCommentId)
             val expected = ResponseEntity(
                 """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because Invalid CommentId"}]}}""",
@@ -447,10 +447,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 notImplementedCreateCommentUseCase,
-                deleteReturnArticleNotFoundError,
-                authorizedMyAuth
+                deleteReturnArticleNotFoundError
             ).delete(requestHeader, pathParamSlug, pathParamCommentId)
             val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
             assertThat(actual).isEqualTo(expected)
@@ -477,10 +477,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 notImplementedCreateCommentUseCase,
-                notFoundError,
-                authorizedMyAuth
+                notFoundError
             ).delete(requestHeader, pathParamSlug, pathParamCommentId)
             val expected = ResponseEntity("""{"errors":{"body":["コメントが見つかりませんでした"]}}""", HttpStatus.valueOf(404))
             assertThat(actual).isEqualTo(expected)
@@ -495,10 +495,10 @@ class CommentControllerTest {
                 }
             }
             val actual = commentController(
+                authorizedMyAuth,
                 notImplementedListCommentUseCase,
                 notImplementedCreateCommentUseCase,
                 deleteReturnUnexpectedError,
-                authorizedMyAuth,
             ).delete(requestHeader, pathParamSlug, pathParamCommentId)
             val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
             assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -29,7 +29,7 @@ import com.example.realworldkotlinspringbootjdbc.domain.comment.Body as CommentB
 
 class CommentControllerTest {
     @Nested
-    class List {
+    class `List JWT 認証成功` {
         private val requestHeader = "hoge-authorize"
         private val pathParam = "hoge-slug"
         val dummyRegisteredUser = RegisteredUser.newWithoutValidation(
@@ -58,7 +58,7 @@ class CommentControllerTest {
         private val notImplementedDeleteCommentUseCase = object : DeleteCommentUseCase {}
 
         @Test
-        fun `コメント取得時、UseCase が「Comment」のリストを返す場合、200レスポンスを返す`() {
+        fun `JWT 認証成功-コメント取得-UseCase が「Comment」のリストを返す場合、200レスポンスを返す`() {
             val mockComments = listOf(
                 Comment.newWithoutValidation(
                     CommentId.newWithoutValidation(1),
@@ -112,7 +112,7 @@ class CommentControllerTest {
         }
 
         @Test
-        fun `コメント取得時、UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
+        fun `JWT 認証成功-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
             val notImplementedError = object : MyError {}
             val listReturnNotFoundError = object : ListCommentUseCase {
                 override fun execute(
@@ -135,7 +135,7 @@ class CommentControllerTest {
         }
 
         @Test
-        fun `コメント取得時、UseCase が「バリデーションエラー」を返す場合、422 エラーレスポンスを返す`() {
+        fun `JWT 認証成功-コメント取得-UseCase が「バリデーションエラー」を返す場合、422 エラーレスポンスを返す`() {
             val notImplementedValidationError = object : MyError.ValidationError {
                 override val message: String get() = "DummyValidationError"
                 override val key: String get() = "DummyKey"
@@ -165,7 +165,7 @@ class CommentControllerTest {
         }
 
         @Test
-        fun `コメント取得時、UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
+        fun `JWT 認証成功-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
             val notImplementedError = object : MyError {}
             val listReturnUnexpectedError = object : ListCommentUseCase {
                 override fun execute(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -293,30 +293,30 @@ class CommentControllerTest {
         fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
             /**
              * FIXME
-             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mock に修正
+             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mockE に修正
              * 命名規則の方針が決まり次第修正
              */
-            val mock = object : MyError.ValidationError {
+            val mockE = object : MyError.ValidationError {
                 override val message: String get() = "DummyValidationError"
                 override val key: String get() = "DummyKey"
             }
 
             /**
              * FIXME
-             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mockUseCase に修正
+             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mockUC に修正
              * 命名規則の方針が決まり次第修正
              */
-            val mockUseCase = object : ListCommentUseCase {
+            val mockUC = object : ListCommentUseCase {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
                 ): Either<ListCommentUseCase.Error, List<Comment>> {
-                    return ListCommentUseCase.Error.InvalidSlug(listOf(mock)).left()
+                    return ListCommentUseCase.Error.InvalidSlug(listOf(mockE)).left()
                 }
             }
             val actual = commentController(
                 unauthorizedMyAuth,
-                mockUseCase,
+                mockUC,
                 notImplementedCreateCommentUseCase,
                 notImplementedDeleteCommentUseCase
             ).list(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -288,35 +288,35 @@ class CommentControllerTest {
             assertThat(actual).isEqualTo(expected)
         }
 
-        @Test
-        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
-            val notImplementedValidationError = object : MyError.ValidationError {
-                override val message: String get() = "DummyValidationError"
-                override val key: String get() = "DummyKey"
-            }
-            val listReturnValidationError = object : ListCommentUseCase {
-                override fun execute(
-                    slug: String?,
-                    currentUser: Option<RegisteredUser>
-                ): Either<ListCommentUseCase.Error, List<Comment>> {
-                    return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
-                }
-            }
-            val actual = commentController(
-                unauthorizedMyAuth,
-                listReturnValidationError,
-                notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase
-            ).list(
-                requestHeader,
-                pathParam
-            )
-            val expected = ResponseEntity(
-                """{"errors":{"body":["記事が見つかりませんでした"]}}""",
-                HttpStatus.valueOf(404)
-            )
-            assertThat(actual).isEqualTo(expected)
-        }
+        // @Test
+        // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
+        //     val notImplementedValidationError = object : MyError.ValidationError {
+        //         override val message: String get() = "DummyValidationError"
+        //         override val key: String get() = "DummyKey"
+        //     }
+        //     val listReturnValidationError = object : ListCommentUseCase {
+        //         override fun execute(
+        //             slug: String?,
+        //             currentUser: Option<RegisteredUser>
+        //         ): Either<ListCommentUseCase.Error, List<Comment>> {
+        //             return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
+        //         }
+        //     }
+        //     val actual = commentController(
+        //         unauthorizedMyAuth,
+        //         listReturnValidationError,
+        //         notImplementedCreateCommentUseCase,
+        //         notImplementedDeleteCommentUseCase
+        //     ).list(
+        //         requestHeader,
+        //         pathParam
+        //     )
+        //     val expected = ResponseEntity(
+        //         """{"errors":{"body":["記事が見つかりませんでした"]}}""",
+        //         HttpStatus.valueOf(404)
+        //     )
+        //     assertThat(actual).isEqualTo(expected)
+        // }
 
         @Test
         fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -338,7 +338,12 @@ class CommentControllerTest {
              * 命名規則の方針が決まり次第修正
              */
             val mockE = object : MyError {}
-            val listReturnUnexpectedError = object : ListCommentUseCase {
+            /**
+             * FIXME
+             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mockUE に修正
+             * 命名規則の方針が決まり次第修正
+             */
+            val mockUE = object : ListCommentUseCase {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
@@ -348,7 +353,7 @@ class CommentControllerTest {
             }
             val actual = commentController(
                 unauthorizedMyAuth,
-                listReturnUnexpectedError,
+                mockUE,
                 notImplementedCreateCommentUseCase,
                 notImplementedDeleteCommentUseCase
             ).list(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -225,7 +225,7 @@ class CommentControllerTest {
                         Username.newWithoutValidation("hoge-author-1"),
                         Bio.newWithoutValidation("hoge-bio-1"),
                         Image.newWithoutValidation("hoge-image-1"),
-                        false,
+                        following = false,
                     )
                 ),
                 Comment.newWithoutValidation(
@@ -238,7 +238,7 @@ class CommentControllerTest {
                         Username.newWithoutValidation("hoge-author-2"),
                         Bio.newWithoutValidation("hoge-bio-2"),
                         Image.newWithoutValidation("hoge-image-2"),
-                        false,
+                        following = false,
                     )
                 ),
             )
@@ -338,6 +338,7 @@ class CommentControllerTest {
              * 命名規則の方針が決まり次第修正
              */
             val mockE = object : MyError {}
+
             /**
              * FIXME
              * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mockUE に修正

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -145,7 +145,7 @@ class CommentControllerTest {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
-                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> {
+                ): Either<ListCommentUseCase.Error, List<Comment>> {
                     return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
                 }
             }

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -36,7 +36,7 @@ class CommentControllerTest {
             deleteCommentUseCase: DeleteCommentUseCase,
             myAuth: MyAuth
         ): CommentController =
-            CommentController(commentsUseCase, createCommentUseCase, deleteCommentUseCase, myAuth)
+            CommentController(myAuth, commentsUseCase, createCommentUseCase, deleteCommentUseCase)
 
         private val notImplementedMyAuth = object : MyAuth {}
 
@@ -180,7 +180,7 @@ class CommentControllerTest {
             deleteCommentUseCase: DeleteCommentUseCase,
             myAuth: MyAuth
         ): CommentController =
-            CommentController(listCommentUseCase, createCommentUseCase, deleteCommentUseCase, myAuth)
+            CommentController(myAuth, listCommentUseCase, createCommentUseCase, deleteCommentUseCase)
 
         private val authorizedMyAuth = object : MyAuth {
             override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> {
@@ -327,7 +327,7 @@ class CommentControllerTest {
             deleteCommentUseCase: DeleteCommentUseCase,
             myAuth: MyAuth
         ): CommentController =
-            CommentController(listCommentUseCase, createCommentUseCase, deleteCommentUseCase, myAuth)
+            CommentController(myAuth, listCommentUseCase, createCommentUseCase, deleteCommentUseCase)
 
         private val authorizedMyAuth = object : MyAuth {
             override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> {

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -235,9 +235,9 @@ class CommentControllerTest {
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-02-02T00:00:00+09:00"),
                     OtherUser.newWithoutValidation(
                         UserId(1),
-                        Username.newWithoutValidation("hoge-author-2"),
-                        Bio.newWithoutValidation("hoge-bio-2"),
-                        Image.newWithoutValidation("hoge-image-2"),
+                        Username.newWithoutValidation("hoge-author-1"),
+                        Bio.newWithoutValidation("hoge-bio-1"),
+                        Image.newWithoutValidation("hoge-image-1"),
                         following = false,
                     )
                 ),

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -29,7 +29,7 @@ import com.example.realworldkotlinspringbootjdbc.domain.comment.Body as CommentB
 
 class CommentControllerTest {
     @Nested
-    class `List JWT 認証成功` {
+    class `List(コメント取得) JWT 認証成功` {
         private val requestHeader = "hoge-authorize"
         private val pathParam = "hoge-slug"
         val dummyRegisteredUser = RegisteredUser.newWithoutValidation(
@@ -177,6 +177,160 @@ class CommentControllerTest {
             }
             val actual = commentController(
                 authorizedMyAuth,
+                listReturnUnexpectedError,
+                notImplementedCreateCommentUseCase,
+                notImplementedDeleteCommentUseCase
+            ).list(
+                requestHeader,
+                pathParam
+            )
+            val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @Nested
+    class `List(コメント取得) JWT 認証失敗 or 未ログイン` {
+        private val requestHeader = "hoge-authorize"
+        private val pathParam = "hoge-slug"
+        private fun commentController(
+            myAuth: MyAuth,
+            commentsUseCase: ListCommentUseCase,
+            createCommentUseCase: CreateCommentUseCase,
+            deleteCommentUseCase: DeleteCommentUseCase
+        ): CommentController =
+            CommentController(myAuth, commentsUseCase, createCommentUseCase, deleteCommentUseCase)
+
+        private val unauthorizedMyAuth = object : MyAuth {
+            override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> {
+                return MyAuth.Unauthorized.RequiredBearerToken.left()
+            }
+        }
+
+        private val notImplementedCreateCommentUseCase = object : CreateCommentUseCase {}
+
+        private val notImplementedDeleteCommentUseCase = object : DeleteCommentUseCase {}
+
+        @Test
+        fun `JWT 認証失敗-コメント取得-UseCase が「Comment」のリストを返す場合、200レスポンスを返す`() {
+            val mockComments = listOf(
+                Comment.newWithoutValidation(
+                    CommentId.newWithoutValidation(1),
+                    CommentBody.newWithoutValidation("hoge-body-1"),
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-01-01T00:00:00+09:00"),
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-01-01T00:00:00+09:00"),
+                    OtherUser.newWithoutValidation(
+                        UserId(1),
+                        Username.newWithoutValidation("hoge-author-1"),
+                        Bio.newWithoutValidation("hoge-bio-1"),
+                        Image.newWithoutValidation("hoge-image-1"),
+                        false,
+                    )
+                ),
+                Comment.newWithoutValidation(
+                    CommentId.newWithoutValidation(2),
+                    CommentBody.newWithoutValidation("hoge-body-2"),
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-02-02T00:00:00+09:00"),
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-02-02T00:00:00+09:00"),
+                    OtherUser.newWithoutValidation(
+                        UserId(1),
+                        Username.newWithoutValidation("hoge-author-2"),
+                        Bio.newWithoutValidation("hoge-bio-2"),
+                        Image.newWithoutValidation("hoge-image-2"),
+                        false,
+                    )
+                ),
+            )
+            val listReturnComment = object : ListCommentUseCase {
+                override fun execute(
+                    slug: String?,
+                    currentUser: Option<RegisteredUser>
+                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
+                    mockComments.right()
+            }
+            val actual =
+                commentController(
+                    unauthorizedMyAuth,
+                    listReturnComment,
+                    notImplementedCreateCommentUseCase,
+                    notImplementedDeleteCommentUseCase
+                ).list(
+                    requestHeader,
+                    pathParam
+                )
+            val expected = ResponseEntity(
+                """{"comments":[{"id":1,"body":"hoge-body-1","createdAt":"2021-12-31T15:00:00.000Z","updatedAt":"2021-12-31T15:00:00.000Z","author":"hoge-author-1"},{"id":2,"body":"hoge-body-2","createdAt":"2022-02-01T15:00:00.000Z","updatedAt":"2022-02-01T15:00:00.000Z","author":"hoge-author-2"}]}""",
+                HttpStatus.valueOf(200)
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `JWT 認証失敗-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
+            val notImplementedError = object : MyError {}
+            val listReturnNotFoundError = object : ListCommentUseCase {
+                override fun execute(
+                    slug: String?,
+                    currentUser: Option<RegisteredUser>
+                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
+                    ListCommentUseCase.Error.NotFound(notImplementedError).left()
+            }
+            val actual = commentController(
+                unauthorizedMyAuth,
+                listReturnNotFoundError,
+                notImplementedCreateCommentUseCase,
+                notImplementedDeleteCommentUseCase
+            ).list(
+                requestHeader,
+                pathParam
+            )
+            val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `JWT 認証失敗-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
+            val notImplementedValidationError = object : MyError.ValidationError {
+                override val message: String get() = "DummyValidationError"
+                override val key: String get() = "DummyKey"
+            }
+            val listReturnValidationError = object : ListCommentUseCase {
+                override fun execute(
+                    slug: String?,
+                    currentUser: Option<RegisteredUser>
+                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> {
+                    return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
+                }
+            }
+            val actual = commentController(
+                unauthorizedMyAuth,
+                listReturnValidationError,
+                notImplementedCreateCommentUseCase,
+                notImplementedDeleteCommentUseCase
+            ).list(
+                requestHeader,
+                pathParam
+            )
+            val expected = ResponseEntity(
+                """{"errors":{"body":["記事が見つかりませんでした"]}}""",
+                HttpStatus.valueOf(404)
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `JWT 認証失敗-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
+            val notImplementedError = object : MyError {}
+            val listReturnUnexpectedError = object : ListCommentUseCase {
+                override fun execute(
+                    slug: String?,
+                    currentUser: Option<RegisteredUser>
+                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> {
+                    return ListCommentUseCase.Error.Unexpected(notImplementedError).left()
+                }
+            }
+            val actual = commentController(
+                unauthorizedMyAuth,
                 listReturnUnexpectedError,
                 notImplementedCreateCommentUseCase,
                 notImplementedDeleteCommentUseCase

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -39,6 +39,7 @@ class CommentControllerTest {
             Bio.newWithoutValidation("dummy-bio"),
             Image.newWithoutValidation("dummy-image"),
         )
+
         private fun commentController(
             myAuth: MyAuth,
             commentsUseCase: ListCommentUseCase,
@@ -245,7 +246,7 @@ class CommentControllerTest {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
-                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
+                ): Either<ListCommentUseCase.Error, List<Comment>> =
                     mockComments.right()
             }
             val actual =
@@ -265,28 +266,28 @@ class CommentControllerTest {
             assertThat(actual).isEqualTo(expected)
         }
 
-        @Test
-        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
-            val notImplementedError = object : MyError {}
-            val listReturnNotFoundError = object : ListCommentUseCase {
-                override fun execute(
-                    slug: String?,
-                    currentUser: Option<RegisteredUser>
-                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
-                    ListCommentUseCase.Error.NotFound(notImplementedError).left()
-            }
-            val actual = commentController(
-                unauthorizedMyAuth,
-                listReturnNotFoundError,
-                notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase
-            ).list(
-                requestHeader,
-                pathParam
-            )
-            val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
-            assertThat(actual).isEqualTo(expected)
-        }
+        // @Test
+        // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
+        //     val notImplementedError = object : MyError {}
+        //     val listReturnNotFoundError = object : ListCommentUseCase {
+        //         override fun execute(
+        //             slug: String?,
+        //             currentUser: Option<RegisteredUser>
+        //         ): Either<ListCommentUseCase.Error, List<Comment>> =
+        //             ListCommentUseCase.Error.NotFound(notImplementedError).left()
+        //     }
+        //     val actual = commentController(
+        //         unauthorizedMyAuth,
+        //         listReturnNotFoundError,
+        //         notImplementedCreateCommentUseCase,
+        //         notImplementedDeleteCommentUseCase
+        //     ).list(
+        //         requestHeader,
+        //         pathParam
+        //     )
+        //     val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
+        //     assertThat(actual).isEqualTo(expected)
+        // }
 
         // @Test
         // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
@@ -318,29 +319,29 @@ class CommentControllerTest {
         //     assertThat(actual).isEqualTo(expected)
         // }
 
-        @Test
-        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
-            val notImplementedError = object : MyError {}
-            val listReturnUnexpectedError = object : ListCommentUseCase {
-                override fun execute(
-                    slug: String?,
-                    currentUser: Option<RegisteredUser>
-                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> {
-                    return ListCommentUseCase.Error.Unexpected(notImplementedError).left()
-                }
-            }
-            val actual = commentController(
-                unauthorizedMyAuth,
-                listReturnUnexpectedError,
-                notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase
-            ).list(
-                requestHeader,
-                pathParam
-            )
-            val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
-            assertThat(actual).isEqualTo(expected)
-        }
+        // @Test
+        // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
+        //     val notImplementedError = object : MyError {}
+        //     val listReturnUnexpectedError = object : ListCommentUseCase {
+        //         override fun execute(
+        //             slug: String?,
+        //             currentUser: Option<RegisteredUser>
+        //         ): Either<ListCommentUseCase.Error, List<Comment>> {
+        //             return ListCommentUseCase.Error.Unexpected(notImplementedError).left()
+        //         }
+        //     }
+        //     val actual = commentController(
+        //         unauthorizedMyAuth,
+        //         listReturnUnexpectedError,
+        //         notImplementedCreateCommentUseCase,
+        //         notImplementedDeleteCommentUseCase
+        //     ).list(
+        //         requestHeader,
+        //         pathParam
+        //     )
+        //     val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
+        //     assertThat(actual).isEqualTo(expected)
+        // }
     }
 
     @Nested

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -295,7 +295,13 @@ class CommentControllerTest {
                 override val message: String get() = "DummyValidationError"
                 override val key: String get() = "DummyKey"
             }
-            val listReturnValidationError = object : ListCommentUseCase {
+
+            /**
+             * FIXME
+             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mock に修正
+             * 命名規則の方針が決まり次第修正
+             */
+            val mock = object : ListCommentUseCase {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
@@ -305,7 +311,7 @@ class CommentControllerTest {
             }
             val actual = commentController(
                 unauthorizedMyAuth,
-                listReturnValidationError,
+                mock,
                 notImplementedCreateCommentUseCase,
                 notImplementedDeleteCommentUseCase
             ).list(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -296,14 +296,14 @@ class CommentControllerTest {
              * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mock に修正
              * 命名規則の方針が決まり次第修正
              */
-            val mockErr = object : MyError.ValidationError {
+            val mock = object : MyError.ValidationError {
                 override val message: String get() = "DummyValidationError"
                 override val key: String get() = "DummyKey"
             }
 
             /**
              * FIXME
-             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mock に修正
+             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mockUseCase に修正
              * 命名規則の方針が決まり次第修正
              */
             val mockUseCase = object : ListCommentUseCase {
@@ -311,7 +311,7 @@ class CommentControllerTest {
                     slug: String?,
                     currentUser: Option<RegisteredUser>
                 ): Either<ListCommentUseCase.Error, List<Comment>> {
-                    return ListCommentUseCase.Error.InvalidSlug(listOf(mockErr)).left()
+                    return ListCommentUseCase.Error.InvalidSlug(listOf(mock)).left()
                 }
             }
             val actual = commentController(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -291,7 +291,12 @@ class CommentControllerTest {
 
         @Test
         fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
-            val notImplementedValidationError = object : MyError.ValidationError {
+            /**
+             * FIXME
+             * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mock に修正
+             * 命名規則の方針が決まり次第修正
+             */
+            val mockError = object : MyError.ValidationError {
                 override val message: String get() = "DummyValidationError"
                 override val key: String get() = "DummyKey"
             }
@@ -301,17 +306,17 @@ class CommentControllerTest {
              * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mock に修正
              * 命名規則の方針が決まり次第修正
              */
-            val mock = object : ListCommentUseCase {
+            val mockUseCase = object : ListCommentUseCase {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
                 ): Either<ListCommentUseCase.Error, List<Comment>> {
-                    return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
+                    return ListCommentUseCase.Error.InvalidSlug(listOf(mockError)).left()
                 }
             }
             val actual = commentController(
                 unauthorizedMyAuth,
-                mock,
+                mockUseCase,
                 notImplementedCreateCommentUseCase,
                 notImplementedDeleteCommentUseCase
             ).list(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -212,7 +212,7 @@ class CommentControllerTest {
         private val notImplementedDeleteCommentUseCase = object : DeleteCommentUseCase {}
 
         @Test
-        fun `JWT 認証失敗-コメント取得-UseCase が「Comment」のリストを返す場合、200レスポンスを返す`() {
+        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「Comment」のリストを返す場合、200レスポンスを返す`() {
             val mockComments = listOf(
                 Comment.newWithoutValidation(
                     CommentId.newWithoutValidation(1),
@@ -266,7 +266,7 @@ class CommentControllerTest {
         }
 
         @Test
-        fun `JWT 認証失敗-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
+        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
             val notImplementedError = object : MyError {}
             val listReturnNotFoundError = object : ListCommentUseCase {
                 override fun execute(
@@ -289,7 +289,7 @@ class CommentControllerTest {
         }
 
         @Test
-        fun `JWT 認証失敗-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
+        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
             val notImplementedValidationError = object : MyError.ValidationError {
                 override val message: String get() = "DummyValidationError"
                 override val key: String get() = "DummyKey"
@@ -319,7 +319,7 @@ class CommentControllerTest {
         }
 
         @Test
-        fun `JWT 認証失敗-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
+        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
             val notImplementedError = object : MyError {}
             val listReturnUnexpectedError = object : ListCommentUseCase {
                 override fun execute(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -296,7 +296,7 @@ class CommentControllerTest {
              * ローカルでは動作するが、Github Actions で動作しない変数名を一時的に mock に修正
              * 命名規則の方針が決まり次第修正
              */
-            val mockError = object : MyError.ValidationError {
+            val mockErr = object : MyError.ValidationError {
                 override val message: String get() = "DummyValidationError"
                 override val key: String get() = "DummyKey"
             }
@@ -311,7 +311,7 @@ class CommentControllerTest {
                     slug: String?,
                     currentUser: Option<RegisteredUser>
                 ): Either<ListCommentUseCase.Error, List<Comment>> {
-                    return ListCommentUseCase.Error.InvalidSlug(listOf(mockError)).left()
+                    return ListCommentUseCase.Error.InvalidSlug(listOf(mockErr)).left()
                 }
             }
             val actual = commentController(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -298,7 +298,7 @@ class CommentControllerTest {
                 override fun execute(
                     slug: String?,
                     currentUser: Option<RegisteredUser>
-                ): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> {
+                ): Either<ListCommentUseCase.Error, List<Comment>> {
                     return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
                 }
             }

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -330,29 +330,29 @@ class CommentControllerTest {
             assertThat(actual).isEqualTo(expected)
         }
 
-        // @Test
-        // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
-        //     val notImplementedError = object : MyError {}
-        //     val listReturnUnexpectedError = object : ListCommentUseCase {
-        //         override fun execute(
-        //             slug: String?,
-        //             currentUser: Option<RegisteredUser>
-        //         ): Either<ListCommentUseCase.Error, List<Comment>> {
-        //             return ListCommentUseCase.Error.Unexpected(notImplementedError).left()
-        //         }
-        //     }
-        //     val actual = commentController(
-        //         unauthorizedMyAuth,
-        //         listReturnUnexpectedError,
-        //         notImplementedCreateCommentUseCase,
-        //         notImplementedDeleteCommentUseCase
-        //     ).list(
-        //         requestHeader,
-        //         pathParam
-        //     )
-        //     val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
-        //     assertThat(actual).isEqualTo(expected)
-        // }
+        @Test
+        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
+            val notImplementedError = object : MyError {}
+            val listReturnUnexpectedError = object : ListCommentUseCase {
+                override fun execute(
+                    slug: String?,
+                    currentUser: Option<RegisteredUser>
+                ): Either<ListCommentUseCase.Error, List<Comment>> {
+                    return ListCommentUseCase.Error.Unexpected(notImplementedError).left()
+                }
+            }
+            val actual = commentController(
+                unauthorizedMyAuth,
+                listReturnUnexpectedError,
+                notImplementedCreateCommentUseCase,
+                notImplementedDeleteCommentUseCase
+            ).list(
+                requestHeader,
+                pathParam
+            )
+            val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
+            assertThat(actual).isEqualTo(expected)
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -260,7 +260,7 @@ class CommentControllerTest {
                     pathParam
                 )
             val expected = ResponseEntity(
-                """{"comments":[{"id":1,"body":"hoge-body-1","createdAt":"2021-12-31T15:00:00.000Z","updatedAt":"2021-12-31T15:00:00.000Z","author":"hoge-author-1"},{"id":2,"body":"hoge-body-2","createdAt":"2022-02-01T15:00:00.000Z","updatedAt":"2022-02-01T15:00:00.000Z","author":"hoge-author-2"}]}""",
+                """{"comments":[{"id":1,"body":"hoge-body-1","createdAt":"2021-12-31T15:00:00.000Z","updatedAt":"2021-12-31T15:00:00.000Z","author":"hoge-author-1"},{"id":2,"body":"hoge-body-2","createdAt":"2022-02-01T15:00:00.000Z","updatedAt":"2022-02-01T15:00:00.000Z","author":"hoge-author-1"}]}""",
                 HttpStatus.valueOf(200)
             )
             assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -289,35 +289,35 @@ class CommentControllerTest {
             assertThat(actual).isEqualTo(expected)
         }
 
-        // @Test
-        // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
-        //     val notImplementedValidationError = object : MyError.ValidationError {
-        //         override val message: String get() = "DummyValidationError"
-        //         override val key: String get() = "DummyKey"
-        //     }
-        //     val listReturnValidationError = object : ListCommentUseCase {
-        //         override fun execute(
-        //             slug: String?,
-        //             currentUser: Option<RegisteredUser>
-        //         ): Either<ListCommentUseCase.Error, List<Comment>> {
-        //             return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
-        //         }
-        //     }
-        //     val actual = commentController(
-        //         unauthorizedMyAuth,
-        //         listReturnValidationError,
-        //         notImplementedCreateCommentUseCase,
-        //         notImplementedDeleteCommentUseCase
-        //     ).list(
-        //         requestHeader,
-        //         pathParam
-        //     )
-        //     val expected = ResponseEntity(
-        //         """{"errors":{"body":["記事が見つかりませんでした"]}}""",
-        //         HttpStatus.valueOf(404)
-        //     )
-        //     assertThat(actual).isEqualTo(expected)
-        // }
+        @Test
+        fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が「バリデーションエラー」を返す場合、404 エラーレスポンスを返す`() {
+            val notImplementedValidationError = object : MyError.ValidationError {
+                override val message: String get() = "DummyValidationError"
+                override val key: String get() = "DummyKey"
+            }
+            val listReturnValidationError = object : ListCommentUseCase {
+                override fun execute(
+                    slug: String?,
+                    currentUser: Option<RegisteredUser>
+                ): Either<ListCommentUseCase.Error, List<Comment>> {
+                    return ListCommentUseCase.Error.InvalidSlug(listOf(notImplementedValidationError)).left()
+                }
+            }
+            val actual = commentController(
+                unauthorizedMyAuth,
+                listReturnValidationError,
+                notImplementedCreateCommentUseCase,
+                notImplementedDeleteCommentUseCase
+            ).list(
+                requestHeader,
+                pathParam
+            )
+            val expected = ResponseEntity(
+                """{"errors":{"body":["記事が見つかりませんでした"]}}""",
+                HttpStatus.valueOf(404)
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
 
         // @Test
         // fun `JWT 認証失敗 or 未ログイン-コメント取得-UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -158,8 +158,8 @@ class CommentControllerTest {
                 pathParam
             )
             val expected = ResponseEntity(
-                """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError"}]}}""",
-                HttpStatus.valueOf(422)
+                """{"errors":{"body":["記事が見つかりませんでした"]}}""",
+                HttpStatus.valueOf(404)
             )
             assertThat(actual).isEqualTo(expected)
         }


### PR DESCRIPTION
<!-- 必要のない項目は削ったり、カスタマイズして使ってください -->

## 概要

get `/articles/{slug}/comments` の際に、JWT 認証による分岐をしていなかったため、追加した。具体的には以下が追加された。

- CommentController にJWT 認証による分岐を追加
- ListCommentUseCase の分岐を追加
- CommentRepository.listに認証ありと認証なしのメソッドを追加

## 対応したこと・やったこと(厳密である必要はありません)

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 行を消して表現しても構いません -->

- ✅/⛔ ユーザーに関係ある機能を実装・変更・改善・修正

<!-- その他の場合、なんとなくでいいので書きましょう -->

※ DX(Developer eXperience: 開発体験=気持ちよく開発・保守できるか)

## 変更・改善・修正するレイヤー

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 3つ以上チェックが付くときは小分けにすることも検討してみてください(しょうがない場合もあります) -->
<!-- 行を消して表現しても構いません -->

- ✅/⛔ Presentation(実装/テスト)
- ✅/⛔ UseCase(実装/テスト)
- ✅/⛔ Domain(実装/テスト)


## 挙動確認する手順

<!-- 行を消して表現しても構いません -->

- ✅/⛔ 挙動確認しなくて良い(眺めて、気になったところ等のレビューが欲しい)
- ✅/⛔ CIが成功(GitHub Actions等が成功してればOK => レビュアーが確認することは無い)


<!--
手動確認の例
1. fooする
2. barする
3. foobarが返ってくることを確認
-->

<!--
curlの場合の例
```
# 成功
$ curl ....
```
-->

----

## レビューする時

[Googleに学ぶコードレビューのポイント](https://cloudsmith.co.jp/blog/efficient/2021/08/1866630.html)

[レビュアーの時によく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

- レビューに粒度はありません
  - 気軽にレビューしていきましょう
  - 気軽に質問していきましょう

## コメントする方へ

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でもOKです。厳密な使い分けは不要です)

- **[MUST]** 必ず修正・変更して欲しい
- **[WANT]** できれば修正・変更して欲しい
- **[IMO]** (In my opinion) 私の意見では
- **[IMHO]** (In my humble opinion) 私のつたない意見では
- **[nits]** (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- **[ASK]** 質問。わからないことがあれば質問してみましょう。
- **[FYI]** (For Your Informatio) 参考までに
- **[GOTCHA]** やったぜ
- **[NP]** 問題ない

## emojiを探す時に便利です（ご活用ください)

[Copy and Paste Emoji](https://getemoji.com/)

## コードレビューたまりがち問題に直面してるな？と感じたら

[「コードレビューたまりがち問題」を解決するには](https://zenn.dev/shun91/articles/thinking-about-code-review)
