### PR TITLE
ProfileControllerTest の showProfile メソッド を TableDrivenTest に移行

### DIFF
--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
@@ -29,8 +29,6 @@ import java.util.stream.Stream
 class ProfileControllerTest {
     @Nested
     class ShowProfile {
-        private val requestHeader = "hoge-authorize"
-        private val pathParam = "hoge-username"
         val dummyRegisteredUser = RegisteredUser.newWithoutValidation(
             UserId(1),
             Email.newWithoutValidation("dummy@example.com"),
@@ -39,9 +37,6 @@ class ProfileControllerTest {
             Image.newWithoutValidation("dummy-image"),
         )
 
-        private val notImplementedFollowProfileUseCase = object : FollowProfileUseCase {}
-        private val notImplementedUnfollowProfileUseCase = object : UnfollowProfileUseCase {}
-
         private fun profileController(
             myAuth: MyAuth,
             showProfileUseCase: ShowProfileUseCase,
@@ -49,12 +44,6 @@ class ProfileControllerTest {
             unfollowProfileUseCase: UnfollowProfileUseCase,
         ): ProfileController =
             ProfileController(myAuth, showProfileUseCase, followProfileUseCase, unfollowProfileUseCase)
-
-        private val authorizedMyAuth = object : MyAuth {
-            override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> {
-                return dummyRegisteredUser.right()
-            }
-        }
 
         data class TestCase(
             val title: String,

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
@@ -17,10 +17,14 @@ import com.example.realworldkotlinspringbootjdbc.usecase.UnfollowProfileUseCase
 import com.example.realworldkotlinspringbootjdbc.util.MyAuth
 import com.example.realworldkotlinspringbootjdbc.util.MyError
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import java.util.stream.Stream
 
 class ProfileControllerTest {
     @Nested
@@ -52,33 +56,51 @@ class ProfileControllerTest {
             }
         }
 
-        @Test
-        fun `プロフィール取得時、 UseCase が「 OtherUser 」を返す場合、 200 レスポンスを返す`() {
-            val mockOtherUser = OtherUser.newWithoutValidation(
-                UserId(1),
-                Username.newWithoutValidation("hoge-username"),
-                Bio.newWithoutValidation("hoge-bio"),
-                Image.newWithoutValidation("hoge-image"),
-                true,
-            )
-            val showProfileReturnProfile = object : ShowProfileUseCase {
-                override fun execute(
-                    username: String?,
-                    currentUser: Option<RegisteredUser>
-                ): Either<ShowProfileUseCase.Error, OtherUser> =
-                    mockOtherUser.right()
+        data class TestCase(
+            val title: String,
+            val useCaseExecuteResult: Either<ShowProfileUseCase.Error, OtherUser>,
+            val expected: ResponseEntity<String>,
+        )
+
+        @TestFactory
+        fun showProfileTest(): Stream<DynamicNode> {
+            return Stream.of(
+                TestCase(
+                    "UseCase:成功（OtherUser）を返す場合、200 レスポンスを返す",
+                    OtherUser.newWithoutValidation(
+                        UserId(1),
+                        Username.newWithoutValidation("hoge-username"),
+                        Bio.newWithoutValidation("hoge-bio"),
+                        Image.newWithoutValidation("hoge-image"),
+                        true,
+                    ).right(),
+                    ResponseEntity<String>(
+                        """{"profile":{"username":"hoge-username","bio":"hoge-bio","image":"hoge-image","following":true}}""",
+                        HttpStatus.valueOf(200),
+                    ),
+                )
+            ).map { testCase ->
+                dynamicTest(testCase.title) {
+                    val actual = profileController(
+                        object : MyAuth {
+                            override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> {
+                                return dummyRegisteredUser.right()
+                            }
+                        },
+                        object : ShowProfileUseCase {
+                            override fun execute(
+                                username: String?,
+                                currentUser: Option<RegisteredUser>
+                            ): Either<ShowProfileUseCase.Error, OtherUser> =
+                                testCase.useCaseExecuteResult
+                        },
+                        object : FollowProfileUseCase {},
+                        object : UnfollowProfileUseCase {}
+                    ).showProfile(rawAuthorizationHeader = "hoge-authorize", username = "hoge-username")
+
+                    assertThat(actual).isEqualTo(testCase.expected)
+                }
             }
-            val actual = profileController(
-                authorizedMyAuth,
-                showProfileReturnProfile,
-                notImplementedFollowProfileUseCase,
-                notImplementedUnfollowProfileUseCase,
-            ).showProfile(requestHeader, pathParam)
-            val expected = ResponseEntity(
-                """{"profile":{"username":"hoge-username","bio":"hoge-bio","image":"hoge-image","following":true}}""",
-                HttpStatus.valueOf(200)
-            )
-            assertThat(actual).isEqualTo(expected)
         }
 
         @Test

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
@@ -98,6 +98,14 @@ class ProfileControllerTest {
                         HttpStatus.valueOf(404)
                     ),
                 ),
+                TestCase(
+                    "UseCase:失敗（Unexpected）を返す場合、500 レスポンスを返す",
+                    ShowProfileUseCase.Error.Unexpected(object : MyError {}).left(),
+                    ResponseEntity(
+                        """{"errors":{"body":["原因不明のエラーが発生しました"]}}""",
+                        HttpStatus.valueOf(500)
+                    ),
+                )
             ).map { testCase ->
                 dynamicTest(testCase.title) {
                     val actual = profileController(
@@ -120,30 +128,6 @@ class ProfileControllerTest {
                     assertThat(actual).isEqualTo(testCase.expected)
                 }
             }
-        }
-
-        @Test
-        fun `プロフィール取得時、 UseCase が原因不明のエラーを返す場合、500 レスポンスを返す`() {
-            val notImplementedError = object : MyError {}
-            val showProfileReturnUnexpectedError = object : ShowProfileUseCase {
-                override fun execute(
-                    username: String?,
-                    currentUser: Option<RegisteredUser>
-                ): Either<ShowProfileUseCase.Error, OtherUser> =
-                    ShowProfileUseCase.Error.Unexpected(notImplementedError).left()
-            }
-            val actual =
-                profileController(
-                    authorizedMyAuth,
-                    showProfileReturnUnexpectedError,
-                    notImplementedFollowProfileUseCase,
-                    notImplementedUnfollowProfileUseCase,
-                ).showProfile(requestHeader, pathParam)
-            val expected = ResponseEntity(
-                """{"errors":{"body":["原因不明のエラーが発生しました"]}}""",
-                HttpStatus.valueOf(500)
-            )
-            assertThat(actual).isEqualTo(expected)
         }
     }
 

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/ProfileControllerTest.kt
@@ -70,10 +70,12 @@ class ProfileControllerTest {
                 ),
                 TestCase(
                     "UseCase:失敗（ValidationError）を返す場合、404 レスポンスを返す",
-                    ShowProfileUseCase.Error.InvalidUsername(listOf(object : MyError.ValidationError {
-                        override val message: String get() = "DummyValidationError InvalidUsername"
-                        override val key: String get() = "DummyKey"
-                    })).left(),
+                    ShowProfileUseCase.Error.InvalidUsername(
+                        listOf(object : MyError.ValidationError {
+                            override val message: String get() = "DummyValidationError InvalidUsername"
+                            override val key: String get() = "DummyKey"
+                        })
+                    ).left(),
                     ResponseEntity(
                         """{"errors":{"body":["プロフィールが見つかりませんでした"]}}""",
                         HttpStatus.valueOf(404)


### PR DESCRIPTION
<!-- 必要のない項目は削ったり、カスタマイズして使ってください -->

## 概要

ProfileControllerTest を Table Driven Test に移行する修正（ https://github.com/sunakan/realworld-kotlin-springboot-jdbc/issues/56 ）。
この PR では、showProfile メソッドをTable Driven Test に移行。
レビュー完了次第、merge 用 ブランチにマージ。

<!-- 必要のない項目は削ったり、カスタマイズして使ってください -->
<!-- issueなどがあれば貼り付けましょう -->
<!-- 感覚的に大きいPRは、小さく切り出せそうなら切り出しましょう -->


## 対応したこと・やったこと(厳密である必要はありません)

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 行を消して表現しても構いません -->

- ✅ 品質向上-テスト追加・改善・修正

※ DX(Developer eXperience: 開発体験=気持ちよく開発・保守できるか)

## 変更・改善・修正するレイヤー

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 3つ以上チェックが付くときは小分けにすることも検討してみてください(しょうがない場合もあります) -->
<!-- 行を消して表現しても構いません -->

- ✅ Presentation(実装/テスト)

## 挙動確認する手順

<!-- 行を消して表現しても構いません -->

- ✅/⛔ CIが成功(GitHub Actions等が成功してればOK => レビュアーが確認することは無い)

<!--
手動確認の例
1. fooする
2. barする
3. foobarが返ってくることを確認
-->

<!--
curlの場合の例
```
# 成功
$ curl ....
```
-->

----

## レビューする時

[Googleに学ぶコードレビューのポイント](https://cloudsmith.co.jp/blog/efficient/2021/08/1866630.html)

[レビュアーの時によく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

- レビューに粒度はありません
  - 気軽にレビューしていきましょう
  - 気軽に質問していきましょう

## コメントする方へ

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でもOKです。厳密な使い分けは不要です)

- **[MUST]** 必ず修正・変更して欲しい
- **[WANT]** できれば修正・変更して欲しい
- **[IMO]** (In my opinion) 私の意見では
- **[IMHO]** (In my humble opinion) 私のつたない意見では
- **[nits]** (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- **[ASK]** 質問。わからないことがあれば質問してみましょう。
- **[FYI]** (For Your Informatio) 参考までに
- **[GOTCHA]** やったぜ
- **[NP]** 問題ない

## emojiを探す時に便利です（ご活用ください)

[Copy and Paste Emoji](https://getemoji.com/)

## コードレビューたまりがち問題に直面してるな？と感じたら

[「コードレビューたまりがち問題」を解決するには](https://zenn.dev/shun91/articles/thinking-about-code-review)
