### PR TITLE
CommentController.list のテストを Table Driven Test に移行

### DIFF
--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -33,7 +33,6 @@ import com.example.realworldkotlinspringbootjdbc.domain.comment.Body as CommentB
 class CommentControllerTest {
     @Nested
     class ListComment {
-        private val pathParam = "hoge-slug"
         private fun commentController(
             commentsUseCase: ListCommentUseCase,
             createCommentUseCase: CreateCommentUseCase,
@@ -41,12 +40,6 @@ class CommentControllerTest {
             myAuth: MyAuth
         ): CommentController =
             CommentController(commentsUseCase, createCommentUseCase, deleteCommentUseCase, myAuth)
-
-        private val notImplementedMyAuth = object : MyAuth {}
-
-        private val notImplementedCreateCommentUseCase = object : CreateCommentUseCase {}
-
-        private val notImplementedDeleteCommentUseCase = object : DeleteCommentUseCase {}
 
         data class TestCase(
             val title: String,
@@ -123,11 +116,11 @@ class CommentControllerTest {
                                 override fun execute(slug: String?): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
                                     testCase.useCaseExecuteResult
                             },
-                            notImplementedCreateCommentUseCase,
-                            notImplementedDeleteCommentUseCase,
-                            notImplementedMyAuth
+                            object : CreateCommentUseCase {},
+                            object : DeleteCommentUseCase {},
+                            object : MyAuth {}
                         ).list(
-                            pathParam
+                            slug = "hoge-slug"
                         )
                     assertThat(actual).isEqualTo(testCase.expected)
                 }

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -19,16 +19,20 @@ import com.example.realworldkotlinspringbootjdbc.usecase.ListCommentUseCase
 import com.example.realworldkotlinspringbootjdbc.util.MyAuth
 import com.example.realworldkotlinspringbootjdbc.util.MyError
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import java.text.SimpleDateFormat
+import java.util.stream.Stream
 import com.example.realworldkotlinspringbootjdbc.domain.comment.Body as CommentBody
 
 class CommentControllerTest {
     @Nested
-    class List {
+    class ListComment {
         private val pathParam = "hoge-slug"
         private fun commentController(
             commentsUseCase: ListCommentUseCase,
@@ -44,54 +48,67 @@ class CommentControllerTest {
 
         private val notImplementedDeleteCommentUseCase = object : DeleteCommentUseCase {}
 
-        @Test
-        fun `コメント取得時、UseCase が「Comment」のリストを返す場合、200レスポンスを返す`() {
-            val mockComments = listOf(
-                Comment.newWithoutValidation(
-                    CommentId.newWithoutValidation(1),
-                    CommentBody.newWithoutValidation("hoge-body-1"),
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-01-01T00:00:00+09:00"),
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-01-01T00:00:00+09:00"),
-                    OtherUser.newWithoutValidation(
-                        UserId(1),
-                        Username.newWithoutValidation("hoge-author-1"),
-                        Bio.newWithoutValidation("hoge-bio-1"),
-                        Image.newWithoutValidation("hoge-image-1"),
-                        false,
+        data class TestCase(
+            val title: String,
+            val useCaseExecuteResult: Either<ListCommentUseCase.Error, List<Comment>>,
+            val expected: ResponseEntity<String>
+        )
+
+        @TestFactory
+        fun listTest(): Stream<DynamicNode> {
+            return Stream.of(
+                TestCase(
+                    "UseCase:成功（List<Comment>）を返す場合、200レスポンスを返す",
+                    listOf(
+                        Comment.newWithoutValidation(
+                            CommentId.newWithoutValidation(1),
+                            CommentBody.newWithoutValidation("hoge-body-1"),
+                            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-01-01T00:00:00+09:00"),
+                            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-01-01T00:00:00+09:00"),
+                            OtherUser.newWithoutValidation(
+                                UserId(1),
+                                Username.newWithoutValidation("hoge-author-1"),
+                                Bio.newWithoutValidation("hoge-bio-1"),
+                                Image.newWithoutValidation("hoge-image-1"),
+                                false,
+                            )
+                        ),
+                        Comment.newWithoutValidation(
+                            CommentId.newWithoutValidation(2),
+                            CommentBody.newWithoutValidation("hoge-body-2"),
+                            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-02-02T00:00:00+09:00"),
+                            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-02-02T00:00:00+09:00"),
+                            OtherUser.newWithoutValidation(
+                                UserId(1),
+                                Username.newWithoutValidation("hoge-author-2"),
+                                Bio.newWithoutValidation("hoge-bio-2"),
+                                Image.newWithoutValidation("hoge-image-2"),
+                                false,
+                            )
+                        ),
+                    ).right(),
+                    ResponseEntity(
+                        """{"comments":[{"id":1,"body":"hoge-body-1","createdAt":"2021-12-31T15:00:00.000Z","updatedAt":"2021-12-31T15:00:00.000Z","author":"hoge-author-1"},{"id":2,"body":"hoge-body-2","createdAt":"2022-02-01T15:00:00.000Z","updatedAt":"2022-02-01T15:00:00.000Z","author":"hoge-author-2"}]}""",
+                        HttpStatus.valueOf(200)
                     )
-                ),
-                Comment.newWithoutValidation(
-                    CommentId.newWithoutValidation(2),
-                    CommentBody.newWithoutValidation("hoge-body-2"),
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-02-02T00:00:00+09:00"),
-                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse("2022-02-02T00:00:00+09:00"),
-                    OtherUser.newWithoutValidation(
-                        UserId(1),
-                        Username.newWithoutValidation("hoge-author-2"),
-                        Bio.newWithoutValidation("hoge-bio-2"),
-                        Image.newWithoutValidation("hoge-image-2"),
-                        false,
-                    )
-                ),
-            )
-            val listReturnComment = object : ListCommentUseCase {
-                override fun execute(slug: String?): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
-                    mockComments.right()
-            }
-            val actual =
-                commentController(
-                    listReturnComment,
-                    notImplementedCreateCommentUseCase,
-                    notImplementedDeleteCommentUseCase,
-                    notImplementedMyAuth
-                ).list(
-                    pathParam
                 )
-            val expected = ResponseEntity(
-                """{"comments":[{"id":1,"body":"hoge-body-1","createdAt":"2021-12-31T15:00:00.000Z","updatedAt":"2021-12-31T15:00:00.000Z","author":"hoge-author-1"},{"id":2,"body":"hoge-body-2","createdAt":"2022-02-01T15:00:00.000Z","updatedAt":"2022-02-01T15:00:00.000Z","author":"hoge-author-2"}]}""",
-                HttpStatus.valueOf(200)
-            )
-            assertThat(actual).isEqualTo(expected)
+            ).map { testCase ->
+                dynamicTest(testCase.title) {
+                    val actual =
+                        commentController(
+                            object : ListCommentUseCase {
+                                override fun execute(slug: String?): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
+                                    testCase.useCaseExecuteResult
+                            },
+                            notImplementedCreateCommentUseCase,
+                            notImplementedDeleteCommentUseCase,
+                            notImplementedMyAuth
+                        ).list(
+                            pathParam
+                        )
+                    assertThat(actual).isEqualTo(testCase.expected)
+                }
+            }
         }
 
         @Test
@@ -424,6 +441,7 @@ class CommentControllerTest {
         @Test
         fun `コメント削除時、UseCase が CommentId に該当するコメントが見つからなかったことに起因する「NotFound」エラーのとき、404 エラーレスポンスを返す`() {
             val notImplementedError = object : MyError {}
+
             /**
              * FIXME
              *   - DeleteCommentUseCaseの実装をもっと良い名前にする

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -109,6 +109,11 @@ class CommentControllerTest {
                         """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError"}]}}""",
                         HttpStatus.valueOf(422)
                     ),
+                ),
+                TestCase(
+                    "UseCase:失敗（Unexpected）を返す場合、500 エラーレスポンスを返す",
+                    ListCommentUseCase.Error.Unexpected(object : MyError {}).left(),
+                    ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500)),
                 )
             ).map { testCase ->
                 dynamicTest(testCase.title) {

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -99,10 +99,12 @@ class CommentControllerTest {
                 ),
                 TestCase(
                     "UseCase:失敗（ValidationError）を返す場合、422 エラーレスポンスを返す",
-                    ListCommentUseCase.Error.InvalidSlug(listOf(object : MyError.ValidationError {
-                        override val message: String get() = "DummyValidationError"
-                        override val key: String get() = "DummyKey"
-                    })).left(),
+                    ListCommentUseCase.Error.InvalidSlug(
+                        listOf(object : MyError.ValidationError {
+                            override val message: String get() = "DummyValidationError"
+                            override val key: String get() = "DummyKey"
+                        })
+                    ).left(),
                     ResponseEntity(
                         """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError"}]}}""",
                         HttpStatus.valueOf(422)

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -34,10 +34,10 @@ class CommentControllerTest {
     @Nested
     class ListComment {
         private fun commentController(
+            myAuth: MyAuth,
             commentsUseCase: ListCommentUseCase,
             createCommentUseCase: CreateCommentUseCase,
-            deleteCommentUseCase: DeleteCommentUseCase,
-            myAuth: MyAuth
+            deleteCommentUseCase: DeleteCommentUseCase
         ): CommentController =
             CommentController(commentsUseCase, createCommentUseCase, deleteCommentUseCase, myAuth)
 
@@ -112,13 +112,13 @@ class CommentControllerTest {
                 dynamicTest(testCase.title) {
                     val actual =
                         commentController(
+                            object : MyAuth {},
                             object : ListCommentUseCase {
                                 override fun execute(slug: String?): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
                                     testCase.useCaseExecuteResult
                             },
                             object : CreateCommentUseCase {},
-                            object : DeleteCommentUseCase {},
-                            object : MyAuth {}
+                            object : DeleteCommentUseCase {}
                         ).list(
                             slug = "hoge-slug"
                         )

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -133,24 +133,6 @@ class CommentControllerTest {
                 }
             }
         }
-
-        @Test
-        fun `コメント取得時、UseCase が原因不明のエラーを返す場合、500 エラーレスポンスを返す`() {
-            val notImplementedError = object : MyError {}
-            val listReturnUnexpectedError = object : ListCommentUseCase {
-                override fun execute(slug: String?): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> {
-                    return ListCommentUseCase.Error.Unexpected(notImplementedError).left()
-                }
-            }
-            val actual = commentController(
-                listReturnUnexpectedError,
-                notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase,
-                notImplementedMyAuth
-            ).list(pathParam)
-            val expected = ResponseEntity("""{"errors":{"body":["原因不明のエラーが発生しました"]}}""", HttpStatus.valueOf(500))
-            assertThat(actual).isEqualTo(expected)
-        }
     }
 
     @Nested

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -91,6 +91,11 @@ class CommentControllerTest {
                         """{"comments":[{"id":1,"body":"hoge-body-1","createdAt":"2021-12-31T15:00:00.000Z","updatedAt":"2021-12-31T15:00:00.000Z","author":"hoge-author-1"},{"id":2,"body":"hoge-body-2","createdAt":"2022-02-01T15:00:00.000Z","updatedAt":"2022-02-01T15:00:00.000Z","author":"hoge-author-2"}]}""",
                         HttpStatus.valueOf(200)
                     )
+                ),
+                TestCase(
+                    "UseCase:失敗（NotFound）を返す場合、404 エラーレスポンスを返す",
+                    ListCommentUseCase.Error.NotFound(object : MyError {}).left(),
+                    ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404)),
                 )
             ).map { testCase ->
                 dynamicTest(testCase.title) {
@@ -109,23 +114,6 @@ class CommentControllerTest {
                     assertThat(actual).isEqualTo(testCase.expected)
                 }
             }
-        }
-
-        @Test
-        fun `コメント取得時、UseCase が「NotFound」を返す場合、404 エラーレスポンスを返す`() {
-            val notImplementedError = object : MyError {}
-            val listReturnNotFoundError = object : ListCommentUseCase {
-                override fun execute(slug: String?): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
-                    ListCommentUseCase.Error.NotFound(notImplementedError).left()
-            }
-            val actual = commentController(
-                listReturnNotFoundError,
-                notImplementedCreateCommentUseCase,
-                notImplementedDeleteCommentUseCase,
-                notImplementedMyAuth
-            ).list(pathParam)
-            val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
-            assertThat(actual).isEqualTo(expected)
         }
 
         @Test


### PR DESCRIPTION
<!-- 必要のない項目は削ったり、カスタマイズして使ってください -->

## 概要

<!-- 必要のない項目は削ったり、カスタマイズして使ってください -->
<!-- issueなどがあれば貼り付けましょう -->
<!-- 感覚的に大きいPRは、小さく切り出せそうなら切り出しましょう -->

CommentController を Table Driven Test に移行する修正（ https://github.com/sunakan/realworld-kotlin-springboot-jdbc/issues/62 ）。
本 PR は merge 用ブランチにマージされる。

## 対応したこと・やったこと(厳密である必要はありません)

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 行を消して表現しても構いません -->

- ✅/⛔ 品質向上-テスト追加・改善・修正


<!-- タスクのように管理しても構いません -->

※ DX(Developer eXperience: 開発体験=気持ちよく開発・保守できるか)

## 変更・改善・修正するレイヤー

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 3つ以上チェックが付くときは小分けにすることも検討してみてください(しょうがない場合もあります) -->
<!-- 行を消して表現しても構いません -->

- ✅/⛔ Presentation(実装/テスト)

## 挙動確認する手順

<!-- 行を消して表現しても構いません -->

- ✅/⛔ CIが成功(GitHub Actions等が成功してればOK => レビュアーが確認することは無い)

<!--
手動確認の例
1. fooする
2. barする
3. foobarが返ってくることを確認
-->

<!--
curlの場合の例
```
# 成功
$ curl ....
```
-->

----

## レビューする時

[Googleに学ぶコードレビューのポイント](https://cloudsmith.co.jp/blog/efficient/2021/08/1866630.html)

[レビュアーの時によく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

- レビューに粒度はありません
  - 気軽にレビューしていきましょう
  - 気軽に質問していきましょう

## コメントする方へ

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でもOKです。厳密な使い分けは不要です)

- **[MUST]** 必ず修正・変更して欲しい
- **[WANT]** できれば修正・変更して欲しい
- **[IMO]** (In my opinion) 私の意見では
- **[IMHO]** (In my humble opinion) 私のつたない意見では
- **[nits]** (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- **[ASK]** 質問。わからないことがあれば質問してみましょう。
- **[FYI]** (For Your Informatio) 参考までに
- **[GOTCHA]** やったぜ
- **[NP]** 問題ない

## emojiを探す時に便利です（ご活用ください)

[Copy and Paste Emoji](https://getemoji.com/)

## コードレビューたまりがち問題に直面してるな？と感じたら

[「コードレビューたまりがち問題」を解決するには](https://zenn.dev/shun91/articles/thinking-about-code-review)
