### PR TITLE
【PR#63マージ待ち】CommentController.create のテストを Table Driven Test に移行

### DIFF
--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -193,12 +193,14 @@ class CommentControllerTest {
                 ),
                 TestCase(
                     "UseCase:失敗（Slug が不正によるValidationError）を返す場合、422 エラーレスポンスを返す",
-                    CreateCommentUseCase.Error.InvalidSlug(listOf(
-                        object : MyError.ValidationError {
-                            override val message: String get() = "DummyValidationError because Invalid Slug"
-                            override val key: String get() = "DummyKey"
-                        }
-                    )).left(),
+                    CreateCommentUseCase.Error.InvalidSlug(
+                        listOf(
+                            object : MyError.ValidationError {
+                                override val message: String get() = "DummyValidationError because Invalid Slug"
+                                override val key: String get() = "DummyKey"
+                            }
+                        )
+                    ).left(),
                     ResponseEntity(
                         """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because Invalid Slug"}]}}""",
                         HttpStatus.valueOf(422)
@@ -206,14 +208,29 @@ class CommentControllerTest {
                 ),
                 TestCase(
                     "コメント作成時、CommentBody が不正であることに起因する「バリデーションエラー」のとき、422 エラーレスポンスを返す",
-                    CreateCommentUseCase.Error.InvalidCommentBody(listOf(object : MyError.ValidationError {
-                        override val message: String get() = "DummyValidationError because invalid CommentBody"
-                        override val key: String get() = "DummyKey"
-                    })).left(),
+                    CreateCommentUseCase.Error.InvalidCommentBody(
+                        listOf(object : MyError.ValidationError {
+                            override val message: String get() = "DummyValidationError because invalid CommentBody"
+                            override val key: String get() = "DummyKey"
+                        })
+                    ).left(),
                     ResponseEntity(
                         """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because invalid CommentBody"}]}}""",
                         HttpStatus.valueOf(422)
                     )
+                ),
+                TestCase(
+                    "コメント作成時、CommentBody が不正であることに起因する「バリデーションエラー」のとき、422 エラーレスポンスを返す",
+                    CreateCommentUseCase.Error.InvalidCommentBody(
+                        listOf(object : MyError.ValidationError {
+                            override val message: String get() = "DummyValidationError because invalid CommentBody"
+                            override val key: String get() = "DummyKey"
+                        })
+                    ).left(),
+                    ResponseEntity(
+                        """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because invalid CommentBody"}]}}""",
+                        HttpStatus.valueOf(422)
+                    ),
                 )
             ).map { testCase ->
                 dynamicTest(testCase.title) {
@@ -238,30 +255,6 @@ class CommentControllerTest {
                     assertThat(actual).isEqualTo(testCase.expected)
                 }
             }
-        }
-
-        @Test
-        fun `コメント作成時、CommentBody が不正であることに起因する「バリデーションエラー」のとき、422 エラーレスポンスを返す`() {
-            val notImplementedValidationError = object : MyError.ValidationError {
-                override val message: String get() = "DummyValidationError because invalid CommentBody"
-                override val key: String get() = "DummyKey"
-            }
-            val createReturnValidationError = object : CreateCommentUseCase {
-                override fun execute(slug: String?, body: String?): Either<CreateCommentUseCase.Error, Comment> {
-                    return CreateCommentUseCase.Error.InvalidCommentBody(listOf(notImplementedValidationError)).left()
-                }
-            }
-            val actual = commentController(
-                authorizedMyAuth,
-                notImplementedListCommentUseCase,
-                createReturnValidationError,
-                notImplementedDeleteCommentUseCase
-            ).create(requestHeader, pathParam, requestBody)
-            val expected = ResponseEntity(
-                """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because invalid CommentBody"}]}}""",
-                HttpStatus.valueOf(422)
-            )
-            assertThat(actual).isEqualTo(expected)
         }
 
         @Test

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -33,6 +33,7 @@ import com.example.realworldkotlinspringbootjdbc.domain.comment.Body as CommentB
 class CommentControllerTest {
     @Nested
     class ListComment {
+        private val pathParam = "hoge-slug"
         private fun commentController(
             myAuth: MyAuth,
             commentsUseCase: ListCommentUseCase,

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -177,7 +177,7 @@ class CommentControllerTest {
                             Username.newWithoutValidation("hoge-username"),
                             Bio.newWithoutValidation(""),
                             Image.newWithoutValidation(""),
-                            true,
+                            following = true,
                         )
                     ).right(),
                     ResponseEntity(

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -33,6 +33,7 @@ import com.example.realworldkotlinspringbootjdbc.domain.comment.Body as CommentB
 class CommentControllerTest {
     @Nested
     class ListComment {
+        val pathParam = "hoge-slug"
         private fun commentController(
             myAuth: MyAuth,
             commentsUseCase: ListCommentUseCase,
@@ -120,7 +121,7 @@ class CommentControllerTest {
                             object : CreateCommentUseCase {},
                             object : DeleteCommentUseCase {}
                         ).list(
-                            slug = "hoge-slug"
+                            pathParam
                         )
                     assertThat(actual).isEqualTo(testCase.expected)
                 }
@@ -146,6 +147,7 @@ class CommentControllerTest {
             Bio.newWithoutValidation("dummy-bio"),
             Image.newWithoutValidation("dummy-image"),
         )
+
         private fun commentController(
             myAuth: MyAuth,
             listCommentUseCase: ListCommentUseCase,

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -33,7 +33,6 @@ import com.example.realworldkotlinspringbootjdbc.domain.comment.Body as CommentB
 class CommentControllerTest {
     @Nested
     class ListComment {
-        private val pathParam = "hoge-slug"
         private fun commentController(
             myAuth: MyAuth,
             commentsUseCase: ListCommentUseCase,

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -203,6 +203,17 @@ class CommentControllerTest {
                         """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because Invalid Slug"}]}}""",
                         HttpStatus.valueOf(422)
                     )
+                ),
+                TestCase(
+                    "コメント作成時、CommentBody が不正であることに起因する「バリデーションエラー」のとき、422 エラーレスポンスを返す",
+                    CreateCommentUseCase.Error.InvalidCommentBody(listOf(object : MyError.ValidationError {
+                        override val message: String get() = "DummyValidationError because invalid CommentBody"
+                        override val key: String get() = "DummyKey"
+                    })).left(),
+                    ResponseEntity(
+                        """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because invalid CommentBody"}]}}""",
+                        HttpStatus.valueOf(422)
+                    )
                 )
             ).map { testCase ->
                 dynamicTest(testCase.title) {
@@ -250,24 +261,6 @@ class CommentControllerTest {
                 """{"errors":{"body":[{"key":"DummyKey","message":"DummyValidationError because invalid CommentBody"}]}}""",
                 HttpStatus.valueOf(422)
             )
-            assertThat(actual).isEqualTo(expected)
-        }
-
-        @Test
-        fun `コメント作成時、Slug に該当する Article が見つからなかったことに起因する「Not Found」エラーのとき、404 エラーレスポンスを返す`() {
-            val notImplementedError = object : MyError {}
-            val createReturnNotFoundError = object : CreateCommentUseCase {
-                override fun execute(slug: String?, body: String?): Either<CreateCommentUseCase.Error, Comment> {
-                    return CreateCommentUseCase.Error.NotFound(notImplementedError).left()
-                }
-            }
-            val actual = commentController(
-                authorizedMyAuth,
-                notImplementedListCommentUseCase,
-                createReturnNotFoundError,
-                notImplementedDeleteCommentUseCase
-            ).create(requestHeader, pathParam, requestBody)
-            val expected = ResponseEntity("""{"errors":{"body":["記事が見つかりませんでした"]}}""", HttpStatus.valueOf(404))
             assertThat(actual).isEqualTo(expected)
         }
 

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/CommentControllerTest.kt
@@ -114,7 +114,7 @@ class CommentControllerTest {
                         commentController(
                             object : MyAuth {},
                             object : ListCommentUseCase {
-                                override fun execute(slug: String?): Either<ListCommentUseCase.Error, kotlin.collections.List<Comment>> =
+                                override fun execute(slug: String?): Either<ListCommentUseCase.Error, List<Comment>> =
                                     testCase.useCaseExecuteResult
                             },
                             object : CreateCommentUseCase {},
@@ -146,8 +146,6 @@ class CommentControllerTest {
             Bio.newWithoutValidation("dummy-bio"),
             Image.newWithoutValidation("dummy-image"),
         )
-        private val notImplementedListCommentUseCase = object : ListCommentUseCase {}
-        private val notImplementedDeleteCommentUseCase = object : DeleteCommentUseCase {}
         private fun commentController(
             myAuth: MyAuth,
             listCommentUseCase: ListCommentUseCase,
@@ -155,12 +153,6 @@ class CommentControllerTest {
             deleteCommentUseCase: DeleteCommentUseCase
         ): CommentController =
             CommentController(listCommentUseCase, createCommentUseCase, deleteCommentUseCase, myAuth)
-
-        private val authorizedMyAuth = object : MyAuth {
-            override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> {
-                return dummyRegisteredUser.right()
-            }
-        }
 
         data class TestCase(
             val title: String,
@@ -243,7 +235,7 @@ class CommentControllerTest {
                                 }
                             },
                             object : DeleteCommentUseCase {}
-                        ).create(pathParam, pathParam, requestBody)
+                        ).create(requestHeader, pathParam, requestBody)
                     assertThat(actual).isEqualTo(testCase.expected)
                 }
             }


### PR DESCRIPTION
<!-- 必要のない項目は削ったり、カスタマイズして使ってください -->

## 概要

<!-- 必要のない項目は削ったり、カスタマイズして使ってください -->
<!-- issueなどがあれば貼り付けましょう -->
<!-- 感覚的に大きいPRは、小さく切り出せそうなら切り出しましょう -->

CommentController.create を Table Driven Test に移行する修正（ https://github.com/sunakan/realworld-kotlin-springboot-jdbc/issues/62 ）。
本 PR は merge 用ブランチにマージされる。

TODO

- [x] https://github.com/sunakan/realworld-kotlin-springboot-jdbc/pull/63 がマージされる

## 対応したこと・やったこと(厳密である必要はありません)

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 行を消して表現しても構いません -->

- ✅/⛔ 品質向上-テスト追加・改善・修正


<!-- タスクのように管理しても構いません -->

※ DX(Developer eXperience: 開発体験=気持ちよく開発・保守できるか)

## 変更・改善・修正するレイヤー

<!-- 箇条書きを全て消して、カスタマイズしても構いません -->
<!-- 3つ以上チェックが付くときは小分けにすることも検討してみてください(しょうがない場合もあります) -->
<!-- 行を消して表現しても構いません -->

- ✅/⛔ Presentation(実装/テスト)

## 挙動確認する手順

<!-- 行を消して表現しても構いません -->

- ✅/⛔ CIが成功(GitHub Actions等が成功してればOK => レビュアーが確認することは無い)

<!--
手動確認の例
1. fooする
2. barする
3. foobarが返ってくることを確認
-->

<!--
curlの場合の例
```
# 成功
$ curl ....
```
-->

----

## レビューする時

[Googleに学ぶコードレビューのポイント](https://cloudsmith.co.jp/blog/efficient/2021/08/1866630.html)

[レビュアーの時によく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

- レビューに粒度はありません
  - 気軽にレビューしていきましょう
  - 気軽に質問していきましょう

## コメントする方へ

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でもOKです。厳密な使い分けは不要です)

- **[MUST]** 必ず修正・変更して欲しい
- **[WANT]** できれば修正・変更して欲しい
- **[IMO]** (In my opinion) 私の意見では
- **[IMHO]** (In my humble opinion) 私のつたない意見では
- **[nits]** (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- **[ASK]** 質問。わからないことがあれば質問してみましょう。
- **[FYI]** (For Your Informatio) 参考までに
- **[GOTCHA]** やったぜ
- **[NP]** 問題ない

## emojiを探す時に便利です（ご活用ください)

[Copy and Paste Emoji](https://getemoji.com/)

## コードレビューたまりがち問題に直面してるな？と感じたら

[「コードレビューたまりがち問題」を解決するには](https://zenn.dev/shun91/articles/thinking-about-code-review)
