### PR TITLE
User関係のPresentation層のテストを記述

### DIFF
--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/UserAndAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/UserAndAuthenticationControllerTest.kt
@@ -51,19 +51,19 @@ class UserAndAuthenticationControllerTest {
             registerUserUseCaseResult: Either<RegisterUserUseCase.Error, RegisteredUser>
         ): UserAndAuthenticationController =
             UserAndAuthenticationController(
-                object : MySessionJwt {
+                mySessionJwt = object : MySessionJwt {
                     override fun encode(session: MySession) = "dummy-jwt-token".right()
                 },
-                object : MyAuth {}, // 関係ない
-                object : RegisterUserUseCase {
+                myAuth = object : MyAuth {}, // 関係ない
+                registerUserUseCase = object : RegisterUserUseCase {
                     override fun execute(
                         email: String?,
                         password: String?,
                         username: String?,
                     ): Either<RegisterUserUseCase.Error, RegisteredUser> = registerUserUseCaseResult
                 },
-                object : LoginUseCase {}, // 関係ない
-                object : UpdateUserUseCase {}, // 関係ない
+                loginUseCase = object : LoginUseCase {}, // 関係ない
+                updateUserUseCase = object : UpdateUserUseCase {}, // 関係ない
             )
 
         @TestFactory
@@ -72,11 +72,11 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "成功: UseCase の実行結果が '登録されたユーザー' の場合、 201 レスポンスを返す",
                     useCaseExecuteResult = RegisteredUser.newWithoutValidation(
-                        UserId(1),
-                        Email.newWithoutValidation("dummy@example.com"),
-                        Username.newWithoutValidation("dummy-username"),
-                        Bio.newWithoutValidation("dummy-bio"),
-                        Image.newWithoutValidation("dummy-image")
+                        userId = UserId(1),
+                        email = Email.newWithoutValidation("dummy@example.com"),
+                        username = Username.newWithoutValidation("dummy-username"),
+                        bio = Bio.newWithoutValidation("dummy-bio"),
+                        image = Image.newWithoutValidation("dummy-image")
                     ).right(),
                     expected = ResponseEntity(
                         """{"user":{"email":"dummy@example.com","username":"dummy-username","bio":"dummy-bio","image":"dummy-image","token":"dummy-jwt-token"}}""",
@@ -101,8 +101,8 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "失敗: UseCase の実行結果が 'Emailが既に登録されている' 旨のエラーの場合、 422 エラーレスポンスを返す",
                     useCaseExecuteResult = RegisterUserUseCase.Error.AlreadyRegisteredEmail(
-                        object : MyError {},
-                        object : UnregisteredUser {
+                        cause = object : MyError {},
+                        user = object : UnregisteredUser {
                             override val email: Email get() = Email.newWithoutValidation("dummy@example.com")
                             override val password: Password get() = Password.newWithoutValidation("dummy-password")
                             override val username: Username get() = Username.newWithoutValidation("dummy-username")
@@ -116,8 +116,8 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "失敗: UseCase の実行結果が 'ユーザー名が既に登録されている' 旨のエラーの場合、 422 エラーレスポンスを返す",
                     useCaseExecuteResult = RegisterUserUseCase.Error.AlreadyRegisteredUsername(
-                        object : MyError {},
-                        object : UnregisteredUser {
+                        cause = object : MyError {},
+                        user = object : UnregisteredUser {
                             override val email: Email get() = Email.newWithoutValidation("dummy@example.com")
                             override val password: Password get() = Password.newWithoutValidation("dummy-password")
                             override val username: Username get() = Username.newWithoutValidation("dummy-username")
@@ -162,18 +162,18 @@ class UserAndAuthenticationControllerTest {
          */
         private fun createUserAndAuthenticationController(loginUseCaseResult: Either<LoginUseCase.Error, RegisteredUser>): UserAndAuthenticationController =
             UserAndAuthenticationController(
-                object : MySessionJwt {
+                mySessionJwt = object : MySessionJwt {
                     override fun encode(session: MySession) = "dummy-jwt-token".right()
                 },
-                object : MyAuth {}, // 関係ない
-                object : RegisterUserUseCase {}, // 関係ない
-                object : LoginUseCase {
+                myAuth = object : MyAuth {}, // 関係ない
+                registerUserUseCase = object : RegisterUserUseCase {}, // 関係ない
+                loginUseCase = object : LoginUseCase {
                     override fun execute(
                         email: String?,
                         password: String?
                     ): Either<LoginUseCase.Error, RegisteredUser> = loginUseCaseResult
                 },
-                object : UpdateUserUseCase {}, // 関係ない
+                updateUserUseCase = object : UpdateUserUseCase {}, // 関係ない
             )
 
         @TestFactory
@@ -182,11 +182,11 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "成功: UseCase の実行結果が '登録されたユーザー' の場合、 201 レスポンスを返す",
                     useCaseExecuteResult = RegisteredUser.newWithoutValidation(
-                        UserId(1),
-                        Email.newWithoutValidation("dummy@example.com"),
-                        Username.newWithoutValidation("dummy-username"),
-                        Bio.newWithoutValidation("dummy-bio"),
-                        Image.newWithoutValidation("dummy-image")
+                        userId = UserId(1),
+                        email = Email.newWithoutValidation("dummy@example.com"),
+                        username = Username.newWithoutValidation("dummy-username"),
+                        bio = Bio.newWithoutValidation("dummy-bio"),
+                        image = Image.newWithoutValidation("dummy-image")
                     ).right(),
                     expected = ResponseEntity(
                         """{"user":{"email":"dummy@example.com","username":"dummy-username","bio":"dummy-bio","image":"dummy-image","token":"dummy-jwt-token"}}""",
@@ -252,15 +252,15 @@ class UserAndAuthenticationControllerTest {
          */
         private fun createUserAndAuthenticationController(authorizeResult: Either<MyAuth.Unauthorized, RegisteredUser>): UserAndAuthenticationController =
             UserAndAuthenticationController(
-                object : MySessionJwt {
+                mySessionJwt = object : MySessionJwt {
                     override fun encode(session: MySession) = "dummy-jwt-token".right()
                 },
-                object : MyAuth {
+                myAuth = object : MyAuth {
                     override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> = authorizeResult
                 },
-                object : RegisterUserUseCase {}, // 関係ない
-                object : LoginUseCase {}, // 関係ない
-                object : UpdateUserUseCase {}, // 関係ない
+                registerUserUseCase = object : RegisterUserUseCase {}, // 関係ない
+                loginUseCase = object : LoginUseCase {}, // 関係ない
+                updateUserUseCase = object : UpdateUserUseCase {}, // 関係ない
             )
 
         @TestFactory
@@ -269,11 +269,11 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "成功: authorize の実行結果が '登録されたユーザー' の場合、 201 レスポンスを返す",
                     authorizeResult = RegisteredUser.newWithoutValidation(
-                        UserId(1),
-                        Email.newWithoutValidation("dummy@example.com"),
-                        Username.newWithoutValidation("dummy-username"),
-                        Bio.newWithoutValidation("dummy-bio"),
-                        Image.newWithoutValidation("dummy-image")
+                        userId = UserId(1),
+                        email = Email.newWithoutValidation("dummy@example.com"),
+                        username = Username.newWithoutValidation("dummy-username"),
+                        bio = Bio.newWithoutValidation("dummy-bio"),
+                        image = Image.newWithoutValidation("dummy-image")
                     ).right(),
                     expected = ResponseEntity(
                         """{"user":{"email":"dummy@example.com","username":"dummy-username","bio":"dummy-bio","image":"dummy-image","token":"dummy-jwt-token"}}""",
@@ -366,21 +366,21 @@ class UserAndAuthenticationControllerTest {
          */
         private fun createUserAndAuthenticationController(updateUserUseCaseResult: Either<UpdateUserUseCase.Error, RegisteredUser>): UserAndAuthenticationController =
             UserAndAuthenticationController(
-                object : MySessionJwt {
+                mySessionJwt = object : MySessionJwt {
                     override fun encode(session: MySession) = "dummy-jwt-token".right()
                 },
-                object : MyAuth {
+                myAuth = object : MyAuth {
                     override fun authorize(bearerToken: String?): Either<MyAuth.Unauthorized, RegisteredUser> = RegisteredUser.newWithoutValidation(
-                        UserId(1),
-                        Email.newWithoutValidation("dummy@example.com"),
-                        Username.newWithoutValidation("dummy-username"),
-                        Bio.newWithoutValidation("dummy-bio"),
-                        Image.newWithoutValidation("dummy-image")
+                        userId = UserId(1),
+                        email = Email.newWithoutValidation("dummy@example.com"),
+                        username = Username.newWithoutValidation("dummy-username"),
+                        bio = Bio.newWithoutValidation("dummy-bio"),
+                        image = Image.newWithoutValidation("dummy-image")
                     ).right()
                 },
-                object : RegisterUserUseCase {}, // 関係ない
-                object : LoginUseCase {}, // 関係ない
-                object : UpdateUserUseCase {
+                registerUserUseCase = object : RegisterUserUseCase {}, // 関係ない
+                loginUseCase = object : LoginUseCase {}, // 関係ない
+                updateUserUseCase = object : UpdateUserUseCase {
                     override fun execute(
                         currentUser: RegisteredUser,
                         email: String?,
@@ -397,11 +397,11 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "成功: UseCase の実行結果が '登録されたユーザー' の場合、 200 レスポンスを返す",
                     useCaseExecuteResult = RegisteredUser.newWithoutValidation(
-                        UserId(1),
-                        Email.newWithoutValidation("dummy@example.com"),
-                        Username.newWithoutValidation("dummy-username"),
-                        Bio.newWithoutValidation("dummy-bio"),
-                        Image.newWithoutValidation("dummy-image")
+                        userId = UserId(1),
+                        email = Email.newWithoutValidation("dummy@example.com"),
+                        username = Username.newWithoutValidation("dummy-username"),
+                        bio = Bio.newWithoutValidation("dummy-bio"),
+                        image = Image.newWithoutValidation("dummy-image")
                     ).right(),
                     expected = ResponseEntity(
                         """{"user":{"email":"dummy@example.com","username":"dummy-username","bio":"dummy-bio","image":"dummy-image","token":"dummy-jwt-token"}}""",
@@ -411,14 +411,14 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "失敗: UseCase の実行結果が '更新しようとしたプロパティが不正である' 旨のエラーの場合、 422 エラーレスポンスを返す",
                     useCaseExecuteResult = UpdateUserUseCase.Error.InvalidAttributesForUpdateUser(
-                        RegisteredUser.newWithoutValidation(
-                            UserId(1),
-                            Email.newWithoutValidation("dummy@example.com"),
-                            Username.newWithoutValidation("dummy-username"),
-                            Bio.newWithoutValidation("dummy-bio"),
-                            Image.newWithoutValidation("dummy-image")
+                        currentUser = RegisteredUser.newWithoutValidation(
+                            userId = UserId(1),
+                            email = Email.newWithoutValidation("dummy@example.com"),
+                            username = Username.newWithoutValidation("dummy-username"),
+                            bio = Bio.newWithoutValidation("dummy-bio"),
+                            image = Image.newWithoutValidation("dummy-image")
                         ),
-                        nonEmptyListOf(
+                        errors = nonEmptyListOf(
                             object : MyError.ValidationError {
                                 override val message: String get() = "dummy-原因"
                                 override val key: String get() = "dummy-プロパティ名"
@@ -433,12 +433,12 @@ class UserAndAuthenticationControllerTest {
                 TestCase(
                     title = "失敗: UseCase の実行結果が '元々のユーザー情報から更新するべき項目' 旨のエラーの場合、 422 エラーレスポンスを返す",
                     useCaseExecuteResult = UpdateUserUseCase.Error.NoChange(
-                        RegisteredUser.newWithoutValidation(
-                            UserId(1),
-                            Email.newWithoutValidation("dummy@example.com"),
-                            Username.newWithoutValidation("dummy-username"),
-                            Bio.newWithoutValidation("dummy-bio"),
-                            Image.newWithoutValidation("dummy-image")
+                        currentUser = RegisteredUser.newWithoutValidation(
+                            userId = UserId(1),
+                            email = Email.newWithoutValidation("dummy@example.com"),
+                            username = Username.newWithoutValidation("dummy-username"),
+                            bio = Bio.newWithoutValidation("dummy-bio"),
+                            image = Image.newWithoutValidation("dummy-image")
                         )
                     ).left(),
                     expected = ResponseEntity(


### PR DESCRIPTION
## 概要

ブランチ名は「impl-test/login-test-for-presentation」ですが、通知含め細か過ぎたと思うので、もうちょっと粒度を荒くしています

- [x] ログインのPresentation層のテストを記述
  - 成功
  - バリデーションエラー
  - 認証失敗
- [x] (ログイン済みである)現在のユーザー情報を取得
  -  成功
  - 認証失敗: BearerTokenがない
  - 認証失敗: BearerTokenのパースに失敗
  - 認証失敗: Decodeに失敗
  - 認証失敗: ユーザーが存在しない
  - 認証失敗: Emailが最新と異なる
- [x] (ログイン済みである)現在のユーザー情報を更新
  -  成功
  - 失敗: バリデーションエラー
  - 失敗: 元々のユーザー情報から更新するべき項目がない

## 依存PR

- https://github.com/sunakan/realworld-kotlin-springboot-jdbc/pull/89

## 問題/課題感(あれば)、改善・提案感

- ログインのPresentation層のテストがなかった

## 対応したこと・やったこと(厳密である必要はありません)

- ✅ 品質向上-テスト追加・改善・修正

※ DX(Developer eXperience: 開発体験=気持ちよく開発・保守できるか)

## 変更・改善・修正するレイヤー

- ✅ Presentation(実装/テスト)

## 挙動確認する手順

- ✅/CIが成功(GitHub Actions等が成功してればOK => レビュアーが確認することは無い)

----

## レビューする時

[Googleに学ぶコードレビューのポイント](https://cloudsmith.co.jp/blog/efficient/2021/08/1866630.html)

[レビュアーの時によく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

- レビューに粒度はありません
  - 気軽にレビューしていきましょう
  - 気軽に質問していきましょう

## コメントする方へ

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でもOKです。厳密な使い分けは不要です)

- **[MUST]** 必ず修正・変更して欲しい
- **[WANT]** できれば修正・変更して欲しい
- **[IMO]** (In my opinion) 私の意見では
- **[IMHO]** (In my humble opinion) 私のつたない意見では
- **[nits]** (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- **[ASK]** 質問。わからないことがあれば質問してみましょう。
- **[FYI]** (For Your Informatio) 参考までに
- **[GOTCHA]** やったぜ
- **[NP]** 問題ない

## emojiを探す時に便利です（ご活用ください)

[Copy and Paste Emoji](https://getemoji.com/)

## コードレビューたまりがち問題に直面してるな？と感じたら

[「コードレビューたまりがち問題」を解決するには](https://zenn.dev/shun91/articles/thinking-about-code-review)
