### PR TITLE
ArticleControllerで利用するNullableArticleを追加

### DIFF
--- a/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/request/NullableArticle.kt
+++ b/src/main/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/request/NullableArticle.kt
@@ -1,0 +1,50 @@
+package com.example.realworldkotlinspringbootjdbc.presentation.request
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonRootName
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+/**
+ * NullableUser
+ *
+ * 用途
+ * - 記事投稿
+ * - 作成済み記事更新
+ *
+ * 概要
+ * - 使い回せるようにする
+ *   - nullを許容する
+ *   - 利用しないkeyも許容する
+ *
+ *  利用例
+ * ```
+ * val article = NullableArticle.from("""{"article":{"title":"dummy-title"}}""")
+ * ```
+ */
+@JsonIgnoreProperties(ignoreUnknown = true) // デシリアライズ時、利用していないkeyがあった時、それを無視する
+@JsonRootName(value = "article")
+data class NullableArticle(
+    @JsonProperty("title") val title: String?,
+    @JsonProperty("description") val description: String?,
+    @JsonProperty("body") val body: String?,
+    @JsonProperty("tagList") val tagList: List<String>?,
+) {
+    companion object {
+        fun from(rawRequestBody: String?): NullableArticle =
+            try {
+                ObjectMapper()
+                    .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+                    .readValue(rawRequestBody!!)
+            } catch (e: Throwable) { // どんなエラーでも拾う
+                NullableArticle(
+                    title = null,
+                    description = null,
+                    body = null,
+                    tagList = null
+                )
+            }
+    }
+}

--- a/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/request/NullableArticleTest.kt
+++ b/src/test/kotlin/com/example/realworldkotlinspringbootjdbc/presentation/request/NullableArticleTest.kt
@@ -1,0 +1,103 @@
+package com.example.realworldkotlinspringbootjdbc.presentation.request
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
+
+class NullableArticleTest {
+    private data class TestCase(
+        val title: String,
+        val rawRequstBody: String?,
+        val expected: NullableArticle
+    )
+
+    @TestFactory
+    fun test(): Stream<DynamicNode> {
+        return Stream.of(
+            TestCase(
+                title = "引数が null の場合、メンバが全て null の NullableArticle が取得できる",
+                rawRequstBody = null,
+                expected = NullableArticle(
+                    title = null,
+                    description = null,
+                    body = null,
+                    tagList = null
+                )
+            ),
+            TestCase(
+                title = "JSON のフォーマットがおかしい場合、メンバが全て null の NullableArticle が取得できる",
+                rawRequstBody = """
+                    {
+                        "article": {}...
+                    }
+                """.trimIndent(),
+                expected = NullableArticle(
+                    title = null,
+                    description = null,
+                    body = null,
+                    tagList = null
+                )
+            ),
+            TestCase(
+                title = "引数のJSON文字列が'user'のobjectを持つが、値が空のオブジェクトの場合、メンバが全て null の NullableArticle が取得できる",
+                rawRequstBody = """
+                    {
+                        "article": {}
+                    }
+                """.trimIndent(),
+                expected = NullableArticle(
+                    title = null,
+                    description = null,
+                    body = null,
+                    tagList = null
+                )
+            ),
+            TestCase(
+                title = "プロパティが揃っている場合、全てのプロパティを持つ NullableArticle が取得できる",
+                rawRequstBody = """
+                    {
+                        "article": {
+                            "title": "dummy-title",
+                            "description": "dummy-description",
+                            "body": "dummy-body",
+                            "tagList": ["dummy-tag-1", "dummy-tag-2"]
+                        }
+                    }
+                """.trimIndent(),
+                expected = NullableArticle(
+                    title = "dummy-title",
+                    description = "dummy-description",
+                    body = "dummy-body",
+                    tagList = listOf("dummy-tag-1", "dummy-tag-2")
+                )
+            ),
+            TestCase(
+                title = "想定していないプロパティがある場合、それを無視した NullableArticle が取得できる",
+                rawRequstBody = """
+                    {
+                        "article": {
+                            "must-ignore": true,
+                            "title": "dummy-title",
+                            "description": "dummy-description",
+                            "body": "dummy-body",
+                            "tagList": []
+                        }
+                    }
+                """.trimIndent(),
+                expected = NullableArticle(
+                    title = "dummy-title",
+                    description = "dummy-description",
+                    body = "dummy-body",
+                    tagList = listOf()
+                )
+            )
+        ).map { testCase ->
+            dynamicTest(testCase.title) {
+                val actual = NullableArticle.from(testCase.rawRequstBody)
+                assertThat(actual).isEqualTo(testCase.expected)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

POST/PUTで使いまわすための、NullableArticleを先に用意

ユーザーからの入力をNullable中たちとして受け取る

## 依存PR

- 無し

## 問題/課題感、改善・提案感

- 無し

## 対応したこと・やったこと(厳密である必要はありません)

<!-- 不要な行は消してください -->

- ✅ ユーザーに関係ある機能を実装・変更・改善・修正

※ DX(Developer eXperience: 開発体験=気持ちよく開発・保守できるか)

## 変更・改善・修正するレイヤー

- ✅ Presentation(実装/テスト)

## 挙動確認する手順

- ✅ CIが成功(GitHub Actions等が成功してればOK => レビュアーが確認することは無い)

----

## レビューする時

[Googleに学ぶコードレビューのポイント](https://cloudsmith.co.jp/blog/efficient/2021/08/1866630.html)

[レビュアーの時によく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

- レビューに粒度はありません
  - 気軽にレビューしていきましょう
  - 気軽に質問していきましょう

## コメントする方へ

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でもOKです。厳密な使い分けは不要です)

- **[MUST]** 必ず修正・変更して欲しい
- **[WANT]** できれば修正・変更して欲しい
- **[IMO]** (In my opinion) 私の意見では
- **[IMHO]** (In my humble opinion) 私のつたない意見では
- **[nits]** (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- **[ASK]** 質問。わからないことがあれば質問してみましょう。
- **[FYI]** (For Your Informatio) 参考までに
- **[GOTCHA]** やったぜ
- **[NP]** 問題ない

## emojiを探す時に便利です（ご活用ください)

[Copy and Paste Emoji](https://getemoji.com/)

## コードレビューたまりがち問題に直面してるな？と感じたら

[「コードレビューたまりがち問題」を解決するには](https://zenn.dev/shun91/articles/thinking-about-code-review)
