### PR TITLE
renovateの設定で、kotlinのjava/spring-bootのバージョンをまとめて扱うようにする

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,15 @@
   ],
 
   //
+  // labels
+  // https://docs.renovatebot.com/configuration-options/#labels
+  //
+  // 概要
+  // - 全てのPRにつけるラベル
+  //
+  labels: ["dependencies"],
+
+  //
   // dependencyDashboard
   // https://docs.renovatebot.com/configuration-options/#dependencydashboard
   //

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,9 +43,15 @@
   packageRules: [
     {
       groupName: "io.swagger.core.v3:swaagger-*",
-      matchPackagePatterns: [
-        "io.swagger.core.v3:swagger-annotations",
-        "io.swagger.core.v3:swagger-models",
+      matchPackagePrefixes: [
+        "io.swagger.core.v3:swagger-",
+      ]
+    },
+    {
+      groupName: "org.jetbrains.kotlin.*",
+      description: "一緒に上げないとCIが落ちる",
+      matchPackagePrefixes: [
+        "org.jetbrains.kotlin.",
       ]
     },
   ],


### PR DESCRIPTION
## 概要

renovateでbuild.gradle.ktsのkotlin周りのバージョンをまとめて扱うようにする

```build.gradle.kts
    kotlin("jvm") version "1.7.10"
    kotlin("plugin.spring") version "1.7.10"
```

## 依存PR

- なし

## 問題/課題感、改善・提案感

- そのままだと、片方ずつ上げることになる

## 対応したこと・やったこと(厳密である必要はありません)

- ✅ DX向上-CI/CD周りの実装・改善・修正

※ DX(Developer eXperience: 開発体験=気持ちよく開発・保守できるか)

## 変更・改善・修正するレイヤー

- ✅ その他(実装/テスト)

## 挙動確認する手順

- ✅ 挙動確認しなくて良い(眺めて、気になったところ等のレビューが欲しい)

----

## レビューする時

[Googleに学ぶコードレビューのポイント](https://cloudsmith.co.jp/blog/efficient/2021/08/1866630.html)

[レビュアーの時によく使うGitHubの便利機能](https://qiita.com/kata_1997/items/fd6cd3009e3d7704f984)

- レビューに粒度はありません
  - 気軽にレビューしていきましょう
  - 気軽に質問していきましょう

## コメントする方へ

以下のようなラベルをつけると温度感や、ざっくりと伝えたいことががわかります(小文字でもOKです。厳密な使い分けは不要です)

- **[MUST]** 必ず修正・変更して欲しい
- **[WANT]** できれば修正・変更して欲しい
- **[IMO]** (In my opinion) 私の意見では
- **[IMHO]** (In my humble opinion) 私のつたない意見では
- **[nits]** (nitpick) ほんの小さな指摘。インデントミスなどの細かいところに。
- **[ASK]** 質問。わからないことがあれば質問してみましょう。
- **[FYI]** (For Your Informatio) 参考までに
- **[GOTCHA]** やったぜ
- **[NP]** 問題ない

## emojiを探す時に便利です（ご活用ください)

[Copy and Paste Emoji](https://getemoji.com/)

## コードレビューたまりがち問題に直面してるな？と感じたら

[「コードレビューたまりがち問題」を解決するには](https://zenn.dev/shun91/articles/thinking-about-code-review)
